### PR TITLE
contract_expression for reusable contractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,35 @@ True
 
 By contracting terms in the correct order we can see that this expression can be computed with N^4 scaling. Even with the overhead of finding the best order or 'path' and small dimensions, opt_einsum is roughly 900 times faster than pure einsum for this expression.
 
+
+## Reusing paths using ``contract_expression``
+
+If you expect to repeatedly use a particular contraction it can make things simpler and more efficient to not compute the path each time. Instead, supplying ``contract_expression`` with the contraction string and the shapes of the tensors generates a ``ContractExpression`` which can then be repeatedly called with any matching set of arrays. For example:
+
+```python
+>>> my_expr = oe.contract_expression("abc,cd,dbe->ea", (2, 3, 4), (4, 5), (5, 3, 6))
+>>> print(my_expr)
+<ContractExpression> for 'abc,cd,dbe->ea':
+  1.  'dbe,cd->bce' [GEMM]
+  2.  'bce,abc->ea' [GEMM]
+```
+
+Now we can call this expression with 3 arrays that match the original shapes without having to compute the path again:
+
+```python
+>>> x, y, z = (np.random.rand(*s) for s in [(2, 3, 4), (4, 5), (5, 3, 6)])
+>>> my_expr(x, y, z)
+array([[ 3.08331541,  4.13708916],
+       [ 2.92793729,  4.57945185],
+       [ 3.55679457,  5.56304115],
+       [ 2.6208398 ,  4.39024187],
+       [ 3.66736543,  5.41450334],
+       [ 3.67772272,  5.46727192]])
+```
+
+Note that few checks are performed when calling the expression, and while it will work for a set of arrays with the same ranks as the original shapes but differing sizes, it might no longer be optimal.
+
+
 ## More details on paths
 
 Finding the optimal order of contraction is not an easy problem and formally scales factorially with respect to the number of terms in the expression. First, lets discuss what a path looks like in opt_einsum:

--- a/opt_einsum/__init__.py
+++ b/opt_einsum/__init__.py
@@ -1,4 +1,4 @@
-from .contract import contract, contract_path
+from .contract import contract, contract_path, contract_expression
 from . import paths
 from . import blas
 from . import helpers

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -434,7 +434,14 @@ class ContractExpression:
         self.einsum_kwargs = einsum_kwargs
         self.contraction_list = contraction_list
 
-    def __call__(self, *arrays, out=None):
+    def __call__(self, *arrays, **kwargs):
+
+        out = kwargs.pop('out', None)
+        if kwargs:
+            raise ValueError("The only valid keyword argument to a "
+                             "`ContractExpression` call is `out=`. "
+                             "Got: %s." % kwargs)
+
         return _core_contract(list(arrays), self.contraction_list,
                               out=out, **self.einsum_kwargs)
 

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -440,13 +440,50 @@ class ContractExpression:
 
 
 class _ShapeOnly(np.ndarray):
+    """Dummy ``numpy.ndarray`` which has a shape only - for generating
+    contract expressions.
+    """
 
     def __init__(self, shape):
         self.shape = shape
 
 
 def contract_expression(subscripts, *shapes, **kwargs):
-    """
+    """Generate an reusable expression for a given contraction with
+    specific shapes, which can for example be cached.
+
+    Parameters
+    ----------
+    subscripts : str
+        Specifies the subscripts for summation.
+    shapes : sequence of integer tuples
+        Shapes of the arrays to optimize the contraction for.
+    kwargs :
+        Passed on to ``contract_path`` or ``einsum``. See ``contract``.
+
+    Returns
+    -------
+    expr : ContractExpression
+        Callable with signature ``expr(*arrays)`` where the array's shapes
+        should match ``shapes``.
+
+    Notes
+    -----
+    - The `out` keyword argument should be supplied to the generated expression
+      rather than this function.
+    - The generated expression will work with any arrays which have
+      the same rank (number of dimensions) as the original shapes, however, if
+      the actual sizes are different, the expression may no longer be optimal.
+
+    Examples
+    --------
+
+    >>> expr = contract_expression("ab,bc->ac", (3, 4), (4, 5))
+    >>> a, b = np.random.rand(3, 4), np.random.rand(4, 5)
+    >>> c = expr(a, b)
+    >>> np.allclose(c, a @ b)
+    True
+
     """
     if not kwargs.get('optimize', True):
         raise ValueError("Can only generate expressions "

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -454,8 +454,7 @@ class ContractExpression:
             raise
 
     def __repr__(self):
-        return ("ContractExpression('%s', contraction_list=%s, einsum_kwargs="
-                "%s)" % (self.contraction, self.contraction_list, self.einsum_kwargs))
+        return "ContractExpression('%s')" % self.contraction
 
     def __str__(self):
         s = "<ContractExpression> for '%s':" % self.contraction

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -164,14 +164,15 @@ def test_contract_expression_checks():
     with pytest.raises(ValueError):
         contract_expression("ab,bc->ac", (2, 3), (3, 4), out=out)
 
-    # check error when wrong arrays supplied to expression
+    # check still get errors when wrong ranks supplied to expression
     expr = contract_expression("ab,bc->ac", (2, 3), (3, 4))
+
+    with pytest.raises(IndexError):
+        expr(np.random.rand(2, 3))
     with pytest.raises(ValueError):
         expr(np.random.rand(2, 3, 4), np.random.rand(3, 4))
-
     with pytest.raises(ValueError):
         expr(np.random.rand(2, 4), np.random.rand(3, 4, 5))
-
     with pytest.raises(ValueError):
         expr(np.random.rand(2, 3), np.random.rand(3, 4),
              out=np.random.rand(2, 4, 6))

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -5,7 +5,7 @@ Tets a series of opt_einsum contraction paths to ensure the results are the same
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
-from opt_einsum import contract, contract_path, helpers
+from opt_einsum import contract, contract_path, helpers, contract_expression
 import pytest
 
 tests = [
@@ -127,3 +127,51 @@ def test_printing():
 
     ein = contract_path(string, *views)
     assert len(ein[1]) == 729
+
+
+@pytest.mark.parametrize("string", tests)
+@pytest.mark.parametrize("optimize", ['greedy', 'optimal'])
+@pytest.mark.parametrize("use_blas", [False, True])
+@pytest.mark.parametrize("out_spec", [False, True])
+def test_contract_expressions(string, optimize, use_blas, out_spec):
+    views = helpers.build_views(string)
+    shapes = [view.shape for view in views]
+    expected = contract(string, *views, optimize=False, use_blas=False)
+
+    expr = contract_expression(
+        string, *shapes, optimize=optimize, use_blas=use_blas)
+
+    if out_spec and ("->" in string) and (string[-2:] != "->"):
+        out, = helpers.build_views(string.split('->')[1])
+        expr(*views, out=out)
+    else:
+        out = expr(*views)
+
+    assert np.allclose(out, expected)
+
+
+def test_contract_expression_checks():
+    # check optimize needed
+    with pytest.raises(ValueError):
+        contract_expression("ab,bc->ac", (2, 3), (3, 4), optimize=False)
+
+    # check sizes are still checked
+    with pytest.raises(ValueError):
+        contract_expression("ab,bc->ac", (2, 3), (3, 4), (42, 42))
+
+    # check if out given
+    out = np.empty((2, 4))
+    with pytest.raises(ValueError):
+        contract_expression("ab,bc->ac", (2, 3), (3, 4), out=out)
+
+    # check error when wrong arrays supplied to expression
+    expr = contract_expression("ab,bc->ac", (2, 3), (3, 4))
+    with pytest.raises(ValueError):
+        expr(np.random.rand(2, 3, 4), np.random.rand(3, 4))
+
+    with pytest.raises(ValueError):
+        expr(np.random.rand(2, 4), np.random.rand(3, 4, 5))
+
+    with pytest.raises(ValueError):
+        expr(np.random.rand(2, 3), np.random.rand(3, 4),
+             out=np.random.rand(2, 4, 6))

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -176,3 +176,7 @@ def test_contract_expression_checks():
     with pytest.raises(ValueError):
         expr(np.random.rand(2, 3), np.random.rand(3, 4),
              out=np.random.rand(2, 4, 6))
+
+    # should only be able to specify out
+    with pytest.raises(ValueError):
+        expr(np.random.rand(2, 3), np.random.rand(3, 4), order='F')


### PR DESCRIPTION
This is a first run at ``contract_expression`` - for building reusable tensor contraction functions based solely on array shapes, which could then for example be cached for efficiency:

```python
>>> expr = contract_expression("ab,bc->ac", (3, 4), (4, 5))
>>> expr
<opt_einsum.contract.ContractExpression at 0x7f68f44801d0>
>>> a, b = np.random.rand(3, 4), np.random.rand(4, 5)
>>> c = expr(a, b)
>>> np.allclose(c, a @ b)
True
```

Closes #10 and might be a useful starting point for #7 (e.g. storing the constant args in the ``ContractExpression``).

Further thoughts
----

1. Semantics / name? The alternate einsum convention is possible but gets pretty unreadable: i.e. ``contract_expression((3, 4), (0, 1), (4, 5), (0, 1))``...
2. More checks? currently these are minimal (I've just tested to make sure that some error is thrown for wrong number of arrays/ranks, i.e. no silent failures). Would defeat the point to have too many run upon every evaluation.
3. Caching seems like such a natural extension that it might be worth including.
4. A stored representation of the contraction might be nice for pretty printing.


I did a little bit of linting/refactoring just to help me add stuff - hope thats alright!