### PR TITLE
Improvements for large networks of tensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Optimized Einsum: A tensor contraction order optimizer
 
  - [Optimizing numpy's einsum function](https://github.com/dgasmith/opt_einsum/blob/master/README.md#optimizing-numpys-einsum-function)
  - [Obtaining the path expression](https://github.com/dgasmith/opt_einsum/blob/master/README.md#obtaining-the-path-expression)
+ - [Reusing paths](https://github.com/dgasmith/opt_einsum/blob/master/README.md#reusing-paths-using-contract_expression)
  - [More details on paths](https://github.com/dgasmith/opt_einsum/blob/master/README.md#more-details-on-paths)
  - [Finding the optimal path](https://github.com/dgasmith/opt_einsum/blob/master/README.md#finding-the-optimal-path)
  - [Finding the opportunistic path](https://github.com/dgasmith/opt_einsum/blob/master/README.md#finding-the-opportunistic-path)

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -118,7 +118,6 @@ def contract_path(*operands, **kwargs):
 
     # Python side parsing
     input_subscripts, output_subscript, operands = parser.parse_einsum_input(operands)
-    subscripts = input_subscripts + '->' + output_subscript
 
     # Build a few useful list and sets
     input_list = input_subscripts.split(',')
@@ -155,7 +154,7 @@ def contract_path(*operands, **kwargs):
             if memory_limit == -1:
                 memory_arg = int(1e20)
             else:
-                raise ValidationError("Memory limit must be larger than 0, or -1")
+                raise ValueError("Memory limit must be larger than 0, or -1")
         else:
             memory_arg = int(memory_limit)
 

--- a/opt_einsum/helpers.py
+++ b/opt_einsum/helpers.py
@@ -4,6 +4,7 @@ Contains helper functions for opt_einsum testing scripts
 
 from __future__ import division, absolute_import, print_function
 
+import itertools
 import numpy as np
 
 chars = 'abcdefghijklmopq'
@@ -118,15 +119,13 @@ def find_contraction(positions, input_sets, output_set):
     ({'a', 'c'}, [{'a', 'c'}, {'a', 'c'}], {'b', 'd'}, {'a', 'b', 'c', 'd'})
     """
 
+    remaining = list(input_sets)
     idx_contract = set()
-    idx_remain = output_set.copy()
-    remaining = []
-    for ind, value in enumerate(input_sets):
-        if ind in positions:
-            idx_contract |= value
-        else:
-            remaining.append(value)
-            idx_remain |= value
+
+    for i in sorted(positions, reverse=True):
+        idx_contract |= remaining.pop(i)
+
+    idx_remain = set(itertools.chain(output_set, *remaining))
 
     new_result = idx_remain & idx_contract
     idx_removed = (idx_contract - new_result)

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -3,6 +3,7 @@ Tets a series of opt_einsum contraction paths to ensure the results are the same
 """
 
 from __future__ import division, absolute_import, print_function
+import sys
 
 import numpy as np
 from opt_einsum import contract, contract_path, helpers, contract_expression
@@ -109,6 +110,23 @@ def test_compare(string):
     assert np.allclose(ein, opt)
 
 
+@pytest.mark.skipif(sys.version_info[0] < 3, reason='requires python3')
+@pytest.mark.parametrize("string", tests)
+def test_compare_greek(string):
+    views = helpers.build_views(string)
+
+    ein = contract(string, *views, optimize=False, use_blas=False)
+
+    # convert to greek
+    string = ''.join(chr(ord(c) + 848) if c not in ',->.' else c for c in string)
+
+    opt = contract(string, *views, optimize='greedy', use_blas=False)
+    assert np.allclose(ein, opt)
+
+    opt = contract(string, *views, optimize='optimal', use_blas=False)
+    assert np.allclose(ein, opt)
+
+
 @pytest.mark.parametrize("string", tests)
 def test_compare_blas(string):
     views = helpers.build_views(string)
@@ -119,6 +137,33 @@ def test_compare_blas(string):
 
     opt = contract(string, *views, optimize='optimal')
     assert np.allclose(ein, opt)
+
+
+@pytest.mark.skipif(sys.version_info[0] < 3, reason='requires python3')
+@pytest.mark.parametrize("string", tests)
+def test_compare_blas_greek(string):
+    views = helpers.build_views(string)
+
+    ein = contract(string, *views, optimize=False)
+
+    # convert to greek
+    string = ''.join(chr(ord(c) + 848) if c not in ',->.' else c for c in string)
+
+    opt = contract(string, *views, optimize='greedy')
+    assert np.allclose(ein, opt)
+
+    opt = contract(string, *views, optimize='optimal')
+    assert np.allclose(ein, opt)
+
+
+@pytest.mark.skipif(sys.version_info[0] < 3, reason='requires python3')
+def test_some_non_alphabet_maintains_order():
+    # 'c beta a' should automatically go to -> 'a c beta'
+    string = 'c' + chr(ord('b') + 848) + 'a'
+    # but beta will be temporarily replaced with 'b' for which 'cba->abc'
+    # so check manual output kicks in:
+    x = np.random.rand(2, 3, 4)
+    assert np.allclose(contract(string, x), contract('cxa', x))
 
 
 def test_printing():

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -169,3 +169,9 @@ def test_greedy_edge_cases():
 
     path, path_str = oe.contract_path(expression, *tensors, path='greedy', memory_limit=-1)
     assert check_path(path, [(0, 1), (0, 2), (0, 1)])
+
+
+def test_can_optimize_outer_products():
+    a, b, c = [np.random.randn(10, 10) for _ in range(3)]
+    d = np.random.randn(10, 2)
+    assert oe.contract_path("ab,cd,ef,fg", a, b, c, d, path='greedy')[0] == [(2, 3), (0, 2), (0, 1)]


### PR DESCRIPTION
This PR contains a couple of improvements for efficiently contracting large networks of tensors, e.g. MPS, PEPS, MERA.

1. Allow ~1000 unique indices to be used. This is only for python3, which uses unicode strings by default. The only trick here really is that calls (e.g. pairwise contractions) to np.einsum must have their string mapped into [a-z,A-Z] with a bit of care taken about ordering.

2. Improve the performance significantly when finding the greedy path for many tensors. This is partly from refactoring ``find_contraction``, which was a hot spot, but mainly from ignoring any potential outer products (which are never advantageous to perform eagerly) while potential inner products are remaining.

For example, finding a path for 200 tensors with ~300 unique indices takes < ~1sec. Although one eventually might want to speed things along with a few manual hints, this is pretty useful functionality.
And from a few small tests, it doesn't seem like much overhead has been introduced for small and/or heavily connected graphs.

Comments obviously welcome!