### PR TITLE
non-numpy (e.g. GPU) backend support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     - python: 2.7
     - python: 3.4
     - python: 3.5
+    - python: 3.6
 
 before_install:
   - uname -a
@@ -21,6 +22,10 @@ before_install:
   - pip install pytest pytest-cov
   - pip install numpy
   - pip install codecov
+  - pip install tensorflow
+  - pip install theano
+  - pip install dask
+  - pip install sparse
   - pip install -e .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - pip install codecov
   - pip install tensorflow
   - pip install theano
-  - pip install dask
+  - pip install dask[array]
   - pip install sparse
   - pip install -e .
 

--- a/README.md
+++ b/README.md
@@ -234,13 +234,17 @@ The final contraction cost is computed and we choose the second path from the li
 
 ## Finding the opportunistic path
 
-Another way to find a path is to choose the best pair to contract at every iteration so that the formula scales like N^3. 
+Another way to find a path is to choose the best pair to contract at every iteration so that the formula scales like N^2. 
 The "best" contraction pair is currently determined by the smallest of the tuple ``(-removed_size, cost)`` where ``removed_size`` is the size of the contracted tensors minus the size of the tensor created and ``cost`` is the cost of the contraction.
 Basically, we want to remove the largest dimensions at the least cost.
 To prevent large outer products the results are sieved by the amount of memory available.
 Overall, this turns out to work extremely well and is only slower than the optimal path in several cases, and even then only by a factor of 2-4 while only taking 1 millisecond for terms of length 10.
 To me, while still not perfect, it represents a "good enough" algorithm for general production.
 It is fast enough that at worst case the overhead penalty is approximately 20 microseconds and is much faster for every other einsum test case I can build or generate randomly.
+
+Since :mod:`opt_einsum` can handle up to a thousand unique indices (which could be increased),
+this greedy approach is also efficient enough to find the contraction path for expressions with hundreds of tensors in less than a second.
+
 
 ## Testing
 

--- a/docs/requirements.yml
+++ b/docs/requirements.yml
@@ -1,0 +1,8 @@
+name: opt-einsum-docs
+channels:
+    - defaults
+dependencies:
+    - python=3
+    - numpy
+    - sphinx
+    - sphinx_rtd_theme

--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -1,0 +1,120 @@
+======================
+Backends & GPU Support
+======================
+
+A brief overview of libraries that have been tested:
+
+    - `tensorflow <https://www.tensorflow.org/>`_: compiled tensor expressions
+      that can run on GPU.
+    - `theano <http://deeplearning.net/software/theano/>`_: compiled tensor
+      expressions that can run on GPU.
+    - `cupy <https://cupy.chainer.org/>`_: numpy-like api for GPU tensors.
+    - `dask <https://dask.pydata.org/>`_: larger-than-memory tensor
+      computations, distributed scheduling, and potential reuse of
+      intermediaries.
+    - `sparse <https://sparse.pydata.org/>`_: sparse tensors.
+
+``opt_einsum`` is quite agnostic to the type of n-dimensional arrays (tensors)
+it uses, since finding the contraction path only relies on getting the shape
+attribute of each array supplied.
+It can perform the underlying tensor contractions with various
+libraries. In fact, any library that provides a :func:`~numpy.tensordot` and
+:func:`~numpy.transpose` implementation can perform most normal contractions.
+While more special functionality such as taking diagonals is reliant on a
+:func:`~numpy.einsum` implementation.
+
+
+
+General backend for any type of array
+-------------------------------------
+
+This 'duck-typing' support just requires specifying the correct ``backend``
+argument for the type of arrays supplied when calling :func:`contract`. For
+example with ``dask``:
+
+.. code-block:: python
+
+    >>> import opt_einsum as oe
+    >>> import dask.array as da
+    >>> shapes = (3, 200), (200, 300), (300, 4)
+    >>> dxs = [da.random.normal(0, 1, shp, chunks=(100, 100)) for shp in shapes]
+    >>> dxs
+    [dask.array<da.random.normal, shape=(3, 200), dtype=float64, chunksize=(3, 100)>,
+     dask.array<da.random.normal, shape=(200, 300), dtype=float64, chunksize=(100, 100)>,
+     dask.array<da.random.normal, shape=(300, 4), dtype=float64, chunksize=(100, 4)>]
+
+
+    >>> dy = oe.contract("ab,bc,cd", *dxs, backend='dask')
+    >>> dy
+    dask.array<transpose, shape=(3, 4), dtype=float64, chunksize=(3, 4)>
+
+    >>> dy.compute()
+    array([[ 470.71404665,    2.44931372,  -28.47577265,  424.37716615],
+           [  64.38328345, -287.40753131,  144.46515642,  324.88169821],
+           [-142.07153553, -180.41739259,  125.0973783 , -239.16754541]])
+
+
+In this case, dask arrays in = dask array out, since dask arrays have a shape
+attribute, and ``opt_einsum`` can find ``dask.array.tensordot`` and
+``dask.array.transpose``.
+
+
+
+Special Backends for numpy arrays - GPU etc.
+----------------------------------------------
+
+A special case is if you want to supply numpy arrays and get numpy arrays back,
+but use a different backend, such as performing a contraction on a GPU.
+Unless the specified backend works on numpy arrays this requires converting to
+and from the backend array type. Currently ``opt_einsum`` can handle this
+automatically for:
+
+    - ``tensorflow``
+    - ``theano``
+    - ``cupy``
+
+which all offer GPU support. Since ``tensorflow`` and ``theano`` both require
+compiling the expression, this functionality is encapsulated in generating a
+:class:`~opt_einsum.ContractExpression` using
+:func:`~opt_einsum.contract_expression`, which can then be called using numpy
+arrays whilst specifiying ``backend='tensorflow'`` etc.
+
+For example with **theano**:
+
+.. code-block:: python
+
+    >>> import opt_einsum as oe
+    >>> shapes = (3, 200), (200, 300), (300, 4)
+    >>> expr = oe.contract_expression("ab,bc,cd", *shapes)
+    >>> expr
+    ContractExpression('ab,bc,cd')
+
+    >>> import numpy as np
+    >>> # GPU advantage mainly for low precision numbers
+    >>> xs = xs = [np.random.randn(*shp).astype(np.float32) for shp in shapes]
+    >>> expr(*xs, backend='theano')  # might see some fluff on first run
+    ...
+    array([[ 129.28352  , -128.00702  , -164.62917  , -335.11682  ],
+           [-462.52344  , -121.12657  ,  -67.847626 ,  624.5457   ],
+           [   5.2838974,   36.441578 ,   81.62851  ,  703.1576   ]],
+          dtype=float32)
+
+To run the expression with **tensorflow**, you need to register a default
+session:
+
+.. code-block:: python
+
+    >>> import tensorflow as tf
+    >>> sess = tf.Session()  # might see some fluff
+    ...
+
+    >>> with sess.as_default(): out = expr(*xs, backend='tensorflow')
+    >>> out
+    array([[ 129.28357  , -128.00684  , -164.62903  , -335.1167   ],
+           [-462.52362  , -121.12659  ,  -67.84769  ,  624.5455   ],
+           [   5.2839584,   36.44155  ,   81.62852  ,  703.15784  ]],
+          dtype=float32)
+
+Note that one could still supply this expression with, for example, a
+``tensorflow.placeholder`` using ``backend='tensorflow'``, and then no
+conversion would take place, instead you'd get a ``tensorflow.Tensor`` back.

--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -29,8 +29,8 @@ General backend for any type of array
 -------------------------------------
 
 This 'duck-typing' support just requires specifying the correct ``backend``
-argument for the type of arrays supplied when calling :func:`contract`. For
-example with ``dask``:
+argument for the type of arrays supplied when calling
+:func:`~opt_einsum.contract`. For example with ``dask``:
 
 .. code-block:: python
 

--- a/docs/source/greedy_path.rst
+++ b/docs/source/greedy_path.rst
@@ -2,10 +2,13 @@
 The Greedy Path
 ===============
 
-Another way to find a path is to choose the best pair to contract at every iteration so that the formula scales like N^3 - functionality provided by :func:`~opt_einsum.paths.greedy`.
+Another way to find a path is to choose the best pair to contract at every iteration so that the formula scales like N^2 - functionality provided by :func:`~opt_einsum.paths.greedy`.
 The "best" contraction pair is currently determined by the smallest of the tuple ``(-removed_size, cost)`` where ``removed_size`` is the size of the contracted tensors minus the size of the tensor created and ``cost`` is the cost of the contraction.
 Basically, we want to remove the largest dimensions at the least cost.
 To prevent large outer products the results are sieved by the amount of memory available.
 Overall, this turns out to work extremely well and is only slower than the optimal path in several cases, and even then only by a factor of 2-4 while only taking 1 millisecond for terms of length 10.
 To me, while still not perfect, it represents a "good enough" algorithm for general production.
 It is fast enough that at worst case the overhead penalty is approximately 20 microseconds and is much faster for every other einsum test case I can build or generate randomly.
+
+Since :mod:`opt_einsum` can handle up to a thousand unique indices (which could be increased),
+this greedy approach is also efficient enough to find the contraction path for expressions with hundreds of tensors in less than a second.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -95,6 +95,7 @@ We can then view more details about the optimized contraction order:
 
    install
    examples
+   backends
 
 
 .. toctree::

--- a/opt_einsum/backends.py
+++ b/opt_einsum/backends.py
@@ -1,0 +1,136 @@
+"""
+Performing array conversions and operations with various backends.
+"""
+
+import importlib
+
+
+# known non top-level imports
+_aliases = {'dask': 'dask.array', 'theano': 'theano.tensor'}
+
+
+def _import_func(func, backend):
+    """Try and import ``{backend}.{func}``, raise an error if library is
+    installed but can't find that particular function.
+    """
+    try:
+        lib = importlib.import_module(_aliases.get(backend, backend))
+        return getattr(lib, func)
+    except AttributeError:
+        raise AttributeError("{} doesn't seem to provide the function {}".format(backend, func))
+
+
+# manually cache functions as python2 doesn't support functools.lru_cache
+_cached_funcs = {}
+
+
+def get_func(func, backend='numpy'):
+    """Return ``{backend}.{func}``, e.g. ``numpy.einsum``, cache result.
+    """
+    try:
+        return _cached_funcs[func, backend]
+    except KeyError:
+        fn = _import_func(func, backend)
+        _cached_funcs[func, backend] = fn
+        return fn
+
+
+# mark libs with einsum, else try to use tensordot/tranpose as much as possible
+_has_einsum = {}
+
+
+def has_einsum(backend):
+    """Check if ``{backend}.einsum`` exists, cache result for performance.
+    """
+    try:
+        return _has_einsum[backend]
+    except KeyError:
+        try:
+            get_func('einsum', backend)
+            _has_einsum[backend] = True
+        except AttributeError:
+            _has_einsum[backend] = False
+
+
+# Tensorflow
+
+def convert_arrays_to_tensorflow(arrays):
+    """Convert numpy arrays to ``tensorflow.placeholder`` instances.
+    """
+    import tensorflow
+    return [tensorflow.placeholder(x.dtype, x.shape) for x in arrays]
+
+
+def build_tensorflow_expression(arrays, expr):
+    """Build a tensorflow function based on ``arrays`` and ``expr``.
+    """
+    import tensorflow
+    placeholders = convert_arrays_to_tensorflow(arrays)
+    graph = expr._normal_contract(placeholders, backend='tensorflow')
+
+    def tensorflow_contract(*arrays):
+        session = tensorflow.get_default_session()
+        return session.run(graph, feed_dict=dict(zip(placeholders, arrays)))
+
+    return tensorflow_contract
+
+
+# Theano
+
+def convert_arrays_to_theano(arrays):
+    """Convert numpy arrays to ``theano.tensor.TensorType`` instances.
+    """
+    import theano
+    return [theano.tensor.TensorType(dtype=x.dtype, broadcastable=[False] * len(x.shape))() for x in arrays]
+
+
+def build_theano_expression(arrays, expr):
+    """Build a theano function based on ``arrays`` and ``expr``.
+    """
+    import theano
+    in_vars = convert_arrays_to_theano(arrays)
+    out_var = expr._normal_contract(in_vars, backend='theano')
+    graph = theano.function(in_vars, out_var)
+
+    def theano_contract(*arrays):
+        return graph(*arrays)
+
+    return theano_contract
+
+
+# Cupy
+
+def convert_arrays_to_cupy(arrays):
+    """Convert numpy arrays to ``cupy.ndarray`` instances.
+    """
+    import cupy
+    return [cupy.asarray(x) for x in arrays]
+
+
+def build_cupy_expression(_, expr):
+    """Build a cupy function based on ``arrays`` and ``expr``.
+    """
+    import cupy
+
+    def cupy_contract(*arrays):
+        cupy_arrays = convert_arrays_to_cupy(arrays)
+        cupy_out = expr._normal_contract(cupy_arrays, backend='cupy')
+        return cupy.asnumpy(cupy_out)
+
+    return cupy_contract
+
+
+# Dispatch to correct expression backend
+
+SPECIAL_BACKENDS = {
+    'tensorflow': build_tensorflow_expression,
+    'theano': build_theano_expression,
+    'cupy': build_cupy_expression,
+}
+
+
+def build_expression(backend, arrays, expr):
+    """Build an expression, based on ``expr`` and initial arrays ``arrays``,
+    that evaluates using backend ``backend``.
+    """
+    return SPECIAL_BACKENDS[backend](arrays, expr)

--- a/opt_einsum/backends.py
+++ b/opt_einsum/backends.py
@@ -108,14 +108,14 @@ def build_theano_expression(arrays, expr):
 
 # Cupy
 
-def convert_arrays_to_cupy(arrays):
+def convert_arrays_to_cupy(arrays):  # pragma: no cover
     """Convert numpy arrays to ``cupy.ndarray`` instances.
     """
     import cupy
     return [cupy.asarray(x) for x in arrays]
 
 
-def build_cupy_expression(_, expr):
+def build_cupy_expression(_, expr):  # pragma: no cover
     """Build a cupy function based on ``arrays`` and ``expr``.
     """
     import cupy

--- a/opt_einsum/backends.py
+++ b/opt_einsum/backends.py
@@ -2,6 +2,7 @@
 Performing array conversions and operations with various backends.
 """
 
+import numpy
 import importlib
 
 
@@ -21,7 +22,12 @@ def _import_func(func, backend):
 
 
 # manually cache functions as python2 doesn't support functools.lru_cache
-_cached_funcs = {}
+#     other libs will be added to this if needed, but pre-populate with numpy
+_cached_funcs = {
+    ('tensordot', 'numpy'): numpy.tensordot,
+    ('transpose', 'numpy'): numpy.transpose,
+    ('einsum', 'numpy'): numpy.einsum,
+}
 
 
 def get_func(func, backend='numpy'):
@@ -50,6 +56,8 @@ def has_einsum(backend):
             _has_einsum[backend] = True
         except AttributeError:
             _has_einsum[backend] = False
+
+        return _has_einsum[backend]
 
 
 # Tensorflow
@@ -121,8 +129,8 @@ def build_cupy_expression(_, expr):
 
 
 # Dispatch to correct expression backend
-
-SPECIAL_BACKENDS = {
+#    these are the backends which support explicit to-and-from numpy conversion
+CONVERT_BACKENDS = {
     'tensorflow': build_tensorflow_expression,
     'theano': build_theano_expression,
     'cupy': build_cupy_expression,
@@ -133,4 +141,4 @@ def build_expression(backend, arrays, expr):
     """Build an expression, based on ``expr`` and initial arrays ``arrays``,
     that evaluates using backend ``backend``.
     """
-    return SPECIAL_BACKENDS[backend](arrays, expr)
+    return CONVERT_BACKENDS[backend](arrays, expr)

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -243,14 +243,14 @@ def contract_path(*operands, **kwargs):
     path_print += "   Theoretical speedup:  %3.3f\n" % (naive_cost / float(opt_cost))
     path_print += "  Largest intermediate:  %.3e elements\n" % max(size_list)
     path_print += "-" * 80 + "\n"
-    path_print += "%6s %6s %24s %40s\n" % header
+    path_print += "%6s %11s %22s %37s\n" % header
     path_print += "-" * 80
 
     for n, contraction in enumerate(contraction_list):
         inds, idx_rm, einsum_str, remaining, do_blas = contraction
         remaining_str = ",".join(remaining) + "->" + output_subscript
         path_run = (scale_list[n], do_blas, einsum_str, remaining_str)
-        path_print += "\n%4d %9s %24s %40s" % path_run
+        path_print += "\n%4d %14s %22s %37s" % path_run
 
     return path, path_print
 
@@ -414,7 +414,7 @@ def _core_contract(operands, contraction_list, backend='numpy', **einsum_kwargs)
     specified_out = out_array is not None
 
     # try and do as much as possible without einsum if not available
-    has_einsum = backends.has_einsum(backend)
+    no_einsum = not backends.has_einsum(backend)
 
     # Start contraction loop
     for num, contraction in enumerate(contraction_list):
@@ -426,8 +426,8 @@ def _core_contract(operands, contraction_list, backend='numpy', **einsum_kwargs)
         # Do we need to deal with the output?
         handle_out = specified_out and ((num + 1) == len(contraction_list))
 
-        # Call tensordot (if blas is None, prefer einsum but only if avail)
-        if blas or (blas is None and not has_einsum):
+        # Call tensordot (check if should prefer einsum, but only if available)
+        if blas and ('EINSUM' not in blas or no_einsum):
 
             # Checks have already been handled
             input_str, results_index = einsum_str.split('->')

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -5,8 +5,8 @@ A functionally equivalent parser of the numpy.einsum input parser
 import numpy as np
 import sys
 
-einsum_symbols_base = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
-einsum_symbols = str(einsum_symbols_base)
+einsum_symbols_base = 'abcdefghijklmnopqrstuvwxyz'
+einsum_symbols = einsum_symbols_base + 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 # boost the number of symbols using unicode if python3
 if sys.version_info[0] >= 3:

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -11,7 +11,7 @@ def optimal(input_sets, output_set, idx_dict, memory_limit):
     on ``memory_limit`` and returns the lowest cost path. This algorithm
     scales factorial with respect to the elements in the list ``input_sets``.
 
-    Paramaters
+    Parameters
     ----------
     input_sets : list
         List of sets that represent the lhs side of the einsum subscript
@@ -187,7 +187,7 @@ def greedy(input_sets, output_set, idx_dict, memory_limit):
     ``memory_limit``. This algorithm scales cubically with respect to the number of
     elements in the list ``input_sets``.
 
-    Paramaters
+    Parameters
     ----------
     input_sets : list
         List of sets that represent the lhs side of the einsum subscript

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -181,11 +181,12 @@ def greedy(input_sets, output_set, idx_dict, memory_limit):
     """
     Finds the path by contracting the best pair until the input list is
     exhausted. The best pair is found by minimizing the tuple
-    ``(-prod(indices_removed), cost)``.  What this amounts to is prioritizing
-    matrix multiplication or inner product operations, then Hadamard like
+    ``(-removed_size, cost)``.  What this amounts to is prioritizing
+    inner product operations, matrix multiplication, then Hadamard like
     operations, and finally outer operations. Outer products are limited by
-    ``memory_limit``. This algorithm scales cubically with respect to the number of
-    elements in the list ``input_sets``.
+    ``memory_limit`` and are ignored until no other operations are
+    available. This algorithm scales quadratically with respect to the
+    number of elements in the list ``input_sets``.
 
     Parameters
     ----------

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+conda:
+    file: docs/requirements.yml
+python:
+    version: 3
+    setup_py_install: true

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -130,7 +130,8 @@ def test_sparse(string):
 
     # sparsify views so they don't become dense during contraction
     for view in views:
-        mask = np.random.choice([False, True], view.shape, True, [0.1, 0.9])
+        np.random.seed(42)
+        mask = np.random.choice([False, True], view.shape, True, [0.05, 0.95])
         view[mask] = 0
 
     ein = contract(string, *views, optimize=False, use_blas=False)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,142 @@
+import pytest
+import numpy as np
+
+from opt_einsum import contract, helpers, contract_expression, backends
+
+try:
+    import tensorflow as tf
+    found_tensorflow = True
+except ImportError:
+    found_tensorflow = False
+
+try:
+    import os
+    os.environ['MKL_THREADING_LAYER'] = 'GNU'
+    import theano
+    found_theano = True
+except ImportError:
+    found_theano = False
+
+try:
+    import cupy
+    found_cupy = True
+except ImportError:
+    found_cupy = False
+
+try:
+    import dask.array as da
+    found_dask = True
+except ImportError:
+    found_dask = False
+
+try:
+    import sparse
+    found_sparse = True
+except ImportError:
+    found_sparse = False
+
+
+tests = [
+    'ab,bc->ca',
+    'abc,bcd,dea',
+    'abc,def->fedcba',
+]
+
+
+@pytest.mark.skipif(not found_tensorflow, reason="Tensorflow not installed.")
+@pytest.mark.parametrize("string", tests)
+def test_tensorflow(string):
+    views = helpers.build_views(string)
+    ein = contract(string, *views, optimize=False, use_blas=False)
+    shps = [v.shape for v in views]
+
+    expr = contract_expression(string, *shps, optimize=True)
+
+    sess = tf.Session()
+    with sess.as_default():
+        opt = expr(*views, backend='tensorflow')
+
+    assert np.allclose(ein, opt)
+
+    # test non-conversion mode
+    tensorflow_views = backends.convert_arrays_to_tensorflow(views)
+    expr(*tensorflow_views, backend='tensorflow')
+
+
+@pytest.mark.skipif(not found_cupy, reason="Cupy not installed.")
+@pytest.mark.parametrize("string", tests)
+def test_cupy(string):
+    views = helpers.build_views(string)
+    ein = contract(string, *views, optimize=False, use_blas=False)
+    shps = [v.shape for v in views]
+
+    expr = contract_expression(string, *shps, optimize=True)
+
+    opt = expr(*views, backend='cupy')
+    assert np.allclose(ein, opt)
+
+    # test non-conversion mode
+    cupy_views = backends.convert_arrays_to_cupy(views)
+    cupy_opt = expr(*cupy_views, backend='cupy')
+    assert isinstance(cupy_opt, cupy.ndarray)
+    assert np.allclose(ein, cupy.asnumpy(cupy_opt))
+
+
+@pytest.mark.skipif(not found_theano, reason="Theano not installed.")
+@pytest.mark.parametrize("string", tests)
+def test_theano(string):
+    views = helpers.build_views(string)
+    ein = contract(string, *views, optimize=False, use_blas=False)
+    shps = [v.shape for v in views]
+
+    expr = contract_expression(string, *shps, optimize=True)
+
+    opt = expr(*views, backend='theano')
+    assert np.allclose(ein, opt)
+
+    # test non-conversion mode
+    theano_views = backends.convert_arrays_to_theano(views)
+    theano_opt = expr(*theano_views, backend='theano')
+    assert isinstance(theano_opt, theano.tensor.TensorVariable)
+
+
+@pytest.mark.skipif(not found_dask, reason="Dask not installed.")
+@pytest.mark.parametrize("string", tests)
+def test_dask(string):
+    views = helpers.build_views(string)
+    ein = contract(string, *views, optimize=False, use_blas=False)
+    shps = [v.shape for v in views]
+    expr = contract_expression(string, *shps, optimize=True)
+
+    # test non-conversion mode
+    da_views = [da.from_array(x, chunks=(2)) for x in views]
+    da_opt = expr(*da_views, backend='dask')
+
+    # check type is maintained when not using numpy arrays
+    assert isinstance(da_opt, da.Array)
+
+    assert np.allclose(ein, np.array(da_opt))
+
+
+@pytest.mark.skipif(not found_sparse, reason="Sparse not installed.")
+@pytest.mark.parametrize("string", tests)
+def test_sparse(string):
+    views = helpers.build_views(string)
+
+    # sparsify views so they don't become dense during contraction
+    for view in views:
+        mask = np.random.choice([False, True], view.shape, True, [0.1, 0.9])
+        view[mask] = 0
+
+    ein = contract(string, *views, optimize=False, use_blas=False)
+    shps = [v.shape for v in views]
+    expr = contract_expression(string, *shps, optimize=True)
+
+    # test non-conversion mode
+    sparse_views = [sparse.COO.from_numpy(x) for x in views]
+    sparse_opt = expr(*sparse_views, backend='sparse')
+
+    # check type is maintained when not using numpy arrays
+    assert isinstance(sparse_opt, sparse.COO)
+
+    assert np.allclose(ein, sparse_opt.todense())

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -70,7 +70,7 @@ def test_tensorflow(string):
 
 @pytest.mark.skipif(not found_cupy, reason="Cupy not installed.")
 @pytest.mark.parametrize("string", tests)
-def test_cupy(string):
+def test_cupy(string):  # pragma: no cover
     views = helpers.build_views(string)
     ein = contract(string, *views, optimize=False, use_blas=False)
     shps = [v.shape for v in views]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -40,6 +40,10 @@ tests = [
     'ab,bc->ca',
     'abc,bcd,dea',
     'abc,def->fedcba',
+    # test 'prefer einsum' ops
+    'ijk,ikj',
+    'i,j->ij',
+    'ijk,k->ij',
 ]
 
 
@@ -48,13 +52,14 @@ tests = [
 def test_tensorflow(string):
     views = helpers.build_views(string)
     ein = contract(string, *views, optimize=False, use_blas=False)
-    shps = [v.shape for v in views]
+    opt = np.empty_like(ein)
 
+    shps = [v.shape for v in views]
     expr = contract_expression(string, *shps, optimize=True)
 
     sess = tf.Session()
     with sess.as_default():
-        opt = expr(*views, backend='tensorflow')
+        expr(*views, backend='tensorflow', out=opt)
 
     assert np.allclose(ein, opt)
 

--- a/tests/test_blas.py
+++ b/tests/test_blas.py
@@ -57,11 +57,11 @@ blas_tests = [
    ((['jli', 'ljk'], 'ik', set('lj')),     'TDOT'), # ST GEMM T N Tensor
 
    # Other
-   ((['ijk', 'ikj'], '', set('ijk')),       False), # Transpose DOT
+   ((['ijk', 'ikj'], '', set('ijk')),       None),  # Transpose DOT
+   ((['i', 'j'], 'ij', set()),              None),  # Outer
+   ((['ijk', 'k'], 'ij', set()),            None),  # Index sum 2
    ((['ijj', 'jk'], 'ik', set('j')),        False), # Double index
-   ((['i', 'j'], 'ij', set()),              False), # Outer
    ((['ijk', 'j'], 'ij', set()),            False), # Index sum 1
-   ((['ijk', 'k'], 'ij', set()),            False), # Index sum 2
 ]
 
 @pytest.mark.parametrize("inp,benchmark", blas_tests)

--- a/tests/test_blas.py
+++ b/tests/test_blas.py
@@ -57,11 +57,12 @@ blas_tests = [
    ((['jli', 'ljk'], 'ik', set('lj')),     'TDOT'), # ST GEMM T N Tensor
 
    # Other
-   ((['ijk', 'ikj'], '', set('ijk')),       None),  # Transpose DOT
-   ((['i', 'j'], 'ij', set()),              None),  # Outer
-   ((['ijk', 'k'], 'ij', set()),            None),  # Index sum 2
-   ((['ijj', 'jk'], 'ik', set('j')),        False), # Double index
-   ((['ijk', 'j'], 'ij', set()),            False), # Index sum 1
+   ((['ijk', 'ikj'], '', set('ijk')),       'DOT/EINSUM'  ),  # Transpose DOT
+   ((['i', 'j'], 'ij', set()),              'OUTER/EINSUM'),  # Outer
+   ((['ijk', 'ik'], 'j', set('ik')),        'GEMV/EINSUM' ),  # Matrix-vector
+   ((['ijj', 'jk'], 'ik', set('j')),        False         ),  # Double index
+   ((['ijk', 'j'], 'ij', set()),            False         ),  # Index sum 1
+   ((['ij', 'ij'], 'ij', set()),            False         ),  # Index sum 2
 ]
 
 @pytest.mark.parametrize("inp,benchmark", blas_tests)

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -241,4 +241,4 @@ def test_contract_expression_checks():
     # should only be able to specify out
     with pytest.raises(ValueError) as err:
         expr(np.random.rand(2, 3), np.random.rand(3, 4), order='F')
-    assert "only valid keyword argument to a `ContractExpression`" in str(err)
+    assert "only valid keyword arguments to a `ContractExpression`" in str(err)


### PR DESCRIPTION
This adds non-numpy backend support to ``opt_einsum`` in two flavors: 

### General duck-typed support

For arbitrary ndarray libraries, i.e. if the arrays supplied have got a ``.shape`` attribute and opt_einsum can find ``{backend}.tensordot`` etc then it should work, returning whatever type the library uses. So for example 

```python
contract("abc,bcd,def->aef", *dask_arrays, backend='dask')
```

 will return a ``dask.Array`` without any explicit logic. I've added tests for [dask](https://github.com/dask/dask/issues/732) and also [sparse](https://github.com/pydata/sparse/issues/31).

Edit: I should add that extra functionality like taking diagonals etc is still reliant on a ``einsum`` implementation. Not sure about broadcasting status etc.

### Special conversion support

To support GPU operations on numpy arrays, here, on first call the arrays are converted to the correct placeholder, an expression generated using these, and then this expression can be called with normal numpy arrays, returning numpy arrays also. E.g.:

```python
expr = contract_expression("abc,bcd,def->aef", *shapes)
expr(*numpy_arrays, backend='theano')
```

Explicit tested support here is for ``tensorflow``, ``theano`` and ``cupy`` - GPU libraries where it makes sense to convert to and from.


### Adding more backends

``contract.py`` doesn't have any explicit reference to the various backends, thats all contained in ``backends.py`` now. So it should be very easy to add new backends. E.g. if ``tblis`` were to add ``tensordot``, it would fall under the duck-typing category above and I think no changes would actually be needed at all.

Obviously any recommendations welcome! Getting the right backend function and all that is cached so I don't think this has added any more than a few 100ns overhead.