### PR TITLE
Stop Codecov failures

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,6 +6,9 @@ coverage:
     - setup.py
   status:
     patch: false
+    project:
+      default:
+        threshold: 80%
 comment:
   layout: "header"
   require_changes: false


### PR DESCRIPTION
Going down in coverage by a marginal amount is ok with me during changes. I dislike the full enforcement so turning that off unless coverage drops below 80%.