### PR TITLE
fix raw contract with backend

### DIFF
--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -58,6 +58,15 @@ def find_output_str(subscripts):
     return output_subscript
 
 
+def possibly_convert_to_numpy(x):
+    """Convert things without a 'shape' to ndarrays, but leave everything else.
+    """
+    if not hasattr(x, 'shape'):
+        return np.asanyarray(x)
+    else:
+        return x
+
+
 def parse_einsum_input(operands):
     """
     A reproduction of einsum c side einsum parsing in python.
@@ -89,7 +98,7 @@ def parse_einsum_input(operands):
 
     if isinstance(operands[0], str):
         subscripts = operands[0].replace(" ", "")
-        operands = [np.asanyarray(v) for v in operands[1:]]
+        operands = [possibly_convert_to_numpy(x) for x in operands[1:]]
 
         # Ensure all characters are valid
         for s in subscripts:
@@ -107,7 +116,7 @@ def parse_einsum_input(operands):
             subscript_list.append(tmp_operands.pop(0))
 
         output_list = tmp_operands[-1] if len(tmp_operands) else None
-        operands = [np.asanyarray(v) for v in operand_list]
+        operands = [possibly_convert_to_numpy(x) for x in operand_list]
         subscripts = ""
         last = len(subscript_list) - 1
         for num, sub in enumerate(subscript_list):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -122,6 +122,11 @@ def test_dask(string):
 
     assert np.allclose(ein, np.array(da_opt))
 
+    # try raw contract
+    da_opt = contract(string, *da_views, backend='dask')
+    assert isinstance(da_opt, da.Array)
+    assert np.allclose(ein, np.array(da_opt))
+
 
 @pytest.mark.skipif(not found_sparse, reason="Sparse not installed.")
 @pytest.mark.parametrize("string", tests)
@@ -145,4 +150,9 @@ def test_sparse(string):
     # check type is maintained when not using numpy arrays
     assert isinstance(sparse_opt, sparse.COO)
 
+    assert np.allclose(ein, sparse_opt.todense())
+
+    # try raw contract
+    sparse_opt = contract(string, *sparse_views, backend='sparse')
+    assert isinstance(sparse_opt, sparse.COO)
     assert np.allclose(ein, sparse_opt.todense())


### PR DESCRIPTION
Quick fix as I had forgotten to test the normal ``contract`` with backend - in its parsing it was converting all operands with ``np.asanyarray(x)``. It now only does this if the operand doesn't have a `shape` attribute.