### PR TITLE
JOSS article

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,12 @@ Consider two different algorithms:
 
 .. code:: python
 
+    import numpy as np
+
+    dim = 10
+    I = np.random.rand(dim, dim, dim, dim)
+    C = np.random.rand(dim, dim)
+
     def naive(I, C):
         # N^8 scaling
         return np.einsum('pi,qj,ijkl,rk,sl->pqrs', C, C, I, C, C)
@@ -35,10 +41,10 @@ in a considerable cost savings even for small N (N=10):
     True
 
     %timeit naive(I, C)
-    1 loops, best of 3: 1.18 s per loop
+    1 loops, best of 3: 829 ms per loop
 
     %timeit optimized(I, C)
-    1000 loops, best of 3: 612 µs per loop
+    1000 loops, best of 3: 445 µs per loop
 
 The index transformation is a well known contraction that leads to
 straightforward intermediates. This contraction can be further
@@ -54,7 +60,15 @@ and can handle all of the logic for you:
 
     from opt_einsum import contract
 
-    contract('pi,qj,ijkl,rk,sl->pqrs', C, C, I, C, C)
+    dim = 30
+    I = np.random.rand(dim, dim, dim, dim)
+    C = np.random.rand(dim, dim)
+
+    %timeit optimized(I, C)
+    10 loops, best of 3: 65.8 ms per loop
+
+    %timeit contract('pi,qj,ijkl,rk,sl->pqrs', C, C, I, C, C)
+    100 loops, best of 3: 16.2 ms per loop
 
 The above will automatically find the optimal contraction order, in this case
 identical to that of the optimized function above, and compute the products for

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,0 +1,74 @@
+@article{NumPy,
+author={S. van der Walt and S. C. Colbert and G. Varoquaux},
+journal={Comput. Sci. Eng.},
+title={The NumPy Array: A Structure for Efficient Numerical Computation},
+year={2011},
+volume={13},
+number={2},
+pages={22-30},
+doi={10.1109/MCSE.2011.37},
+ISSN={1521-9615},
+month={March},}
+
+@Misc{Dask,
+  title = {Dask: Library for dynamic task scheduling},
+  author = {{Dask Development Team}},
+  year = {2016},
+  url = {http://dask.pydata.org},
+  note  = {(accessed date May 9th, 2018)}
+}
+
+@article{Tensorflow,
+  author    = {Mart{\'{\i}}n Abadi and
+               Ashish Agarwal and
+               Paul Barham and
+               Eugene Brevdo and
+               Zhifeng Chen and
+               Craig Citro and
+               Gregory S. Corrado and
+               Andy Davis and
+               Jeffrey Dean and
+               Matthieu Devin and
+               Sanjay Ghemawat and
+               Ian J. Goodfellow and
+               Andrew Harp and
+               Geoffrey Irving and
+               Michael Isard and
+               Yangqing Jia and
+               Rafal J{\'{o}}zefowicz and
+               Lukasz Kaiser and
+               Manjunath Kudlur and
+               Josh Levenberg and
+               Dan Man{\'{e}} and
+               Rajat Monga and
+               Sherry Moore and
+               Derek Gordon Murray and
+               Chris Olah and
+               Mike Schuster and
+               Jonathon Shlens and
+               Benoit Steiner and
+               Ilya Sutskever and
+               Kunal Talwar and
+               Paul A. Tucker and
+               Vincent Vanhoucke and
+               Vijay Vasudevan and
+               Fernanda B. Vi{\'{e}}gas and
+               Oriol Vinyals and
+               Pete Warden and
+               Martin Wattenberg and
+               Martin Wicke and
+               Yuan Yu and
+               Xiaoqiang Zheng},
+  title     = {TensorFlow: Large-Scale Machine Learning on Heterogeneous Distributed
+               Systems},
+  journal   = {CoRR},
+  volume    = {abs/1603.04467},
+  year      = {2016},
+  url       = {http://arxiv.org/abs/1603.04467},
+  archivePrefix = {arXiv},
+  eprint    = {1603.04467},
+  timestamp = {Wed, 07 Jun 2017 14:40:20 +0200},
+  biburl    = {https://dblp.org/rec/bib/journals/corr/AbadiABBCCCDDDG16},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -12,11 +12,14 @@ authors:
    orcid: 0000-0001-8626-0900
    affiliation: "1"
  - name: Johnnie Gray
-   orcid: 0000-000x-xxxx-xxxx
+   orcid: 0000-0001-9461-3024
    affiliation: "2"
+
 affiliations:
  - name: The Molecular Science Software Institute, Blacksburg, VA 24060
    index: 1
+ - name: University College London, London, UK
+   index: 2
 date: 14 May 2018
 bibliography: paper.bib
 ---

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -26,11 +26,22 @@ bibliography: paper.bib
 
 # Summary
 
-``einsum`` is a powerful swiss army knife for arbitrary tensor contractions
-found in the popular ``numpy`` [@NumPy] repository.  However, this function is
-not able to break large expressions into multiple smaller pieces. For example,
-consider the following index transformation: M_{pqrs} = C_{pi} C_{qj} I_{ijkl}
-C_{rk} C_{sl} with two different algorithms:
+``einsum`` is a powerful Swiss army knife for arbitrary tensor contractions
+found in the popular ``numpy`` [@NumPy] repository.  While these expressions
+can be used to form most mathematical expressions found in NumPy, the
+optimization of these expressions becomes increasingly important as the number
+of tensors increases due to finding optimal contraction order greatly effects
+the overall performance. Expressions with many tensors are particularly
+prevalent in many-body theories such as quantum chemistry, particle physics,
+and nuclear physics in addition to other fields such as machine learning.
+At the extreme case, matrix product state theory can have thousands of tensors
+meaning that the computation cannot procede in a naive fashion. ``opt_einsum``
+is particularly suited for these kinds of cases.
+
+However, this function is The ``einsum`` function considers expressions as a
+single unit and is not able to factor these expressions into multiple smaller
+pieces. For example, consider the following index transformation: M_{pqrs} =
+C_{pi} C_{qj} I_{ijkl} C_{rk} C_{sl} with two different algorithms:
 
 ```python
 import numpy as np


### PR DESCRIPTION
This PR starts a [JOSS](http://joss.theoj.org) article to publish this repo. I have added @jcmgray as a co-author due to the large number of changes made to the backend functionality. Any other contributor is more than welcome on the paper if they are willing to read over the draft and approve it.

For now, the paper mostly reproduces the docs intro. However, considering the generic nature of the journal we may need to spend a bit more time discussing what `einsum` and tensor contractions are.

I would also like to coincide this with another `opt_einsum` release, many changes have happened since the last one. Perhaps a 2.0 due to the many backend changes.

Closes #14.