### PR TITLE
[WIP] allow constant tensors in expressions

### DIFF
--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -137,7 +137,7 @@ If ``theano`` is installed, using it as backend is as simple as specifiying
     >>> shapes = (3, 200), (200, 300), (300, 4)
     >>> expr = oe.contract_expression("ab,bc,cd", *shapes)
     >>> expr
-    ContractExpression('ab,bc,cd')
+    <ContractExpression('ab,bc,cd')>
 
     >>> import numpy as np
     >>> # GPU advantage mainly for low precision numbers

--- a/docs/source/reusing_paths.rst
+++ b/docs/source/reusing_paths.rst
@@ -8,7 +8,7 @@ If you expect to repeatedly use a particular contraction it can make things simp
 
     >>> my_expr = oe.contract_expression("abc,cd,dbe->ea", (2, 3, 4), (4, 5), (5, 3, 6))
     >>> print(my_expr)
-    <ContractExpression> for 'abc,cd,dbe->ea':
+    <ContractExpression('abc,cd,dbe->ea')>
       1.  'dbe,cd->bce' [GEMM]
       2.  'bce,abc->ea' [GEMM]
 

--- a/docs/source/reusing_paths.rst
+++ b/docs/source/reusing_paths.rst
@@ -26,3 +26,73 @@ The ``ContractExpression`` can be called with 3 arrays that match the original s
            [ 3.67772272,  5.46727192]])
 
 Note that few checks are performed when calling the expression, and while it will work for a set of arrays with the same ranks as the original shapes but differing sizes, it might no longer be optimal.
+
+
+====================
+Specifying Constants
+====================
+
+Often one generates contraction expressions where some of the tensor arguments
+will remain *constant* across many calls.
+:func:`~opt_einsum.contract_expression` allows you to specify the indices of
+these constant arguments, allowing ``opt_einsum`` to build and then reuse as
+many constant contractions as possible. Take for example the equation:
+
+.. code:: python
+
+    >>> eq = "ij,jk,kl,lm,mn->ni"
+
+where we know that only the first and last tensors will vary between calls.
+We can specify this by marking the middle three as constant - we then need to
+supply the actual arrays rather than just the shapes to
+:func:`~opt_einsum.contract_expression`:
+
+.. code:: python
+
+    >>> # the shapes of the expression
+    >>> args = [(9, 5), (5, 5), (5, 5), (5, 5), (5, 8)]
+
+    >>> # now replace the constants with actual arrays
+    >>> constants = [1, 2, 3]
+    >>> for i in constant:
+    ...     args[i] = np.random.rand(*args[i])
+
+    >>> expr = oe.contract_expression(eq, *args, constants=constants)
+    >>> expr
+    <ContractExpression('ij,[jk,kl,lm],mn->ni', constants=[1, 2, 3])>
+
+The expression now only takes the remaining two arrays as arguments (the
+tensors with ``'ij'`` and ``'mn'`` indices), and will store as many resuable
+constant contractions as possible.
+
+.. code:: python
+
+    >>> out1 = expr(np.random.rand(9, 5), np.random.rand(5, 8))
+    >>> out1.shape
+    (8, 9)
+
+    >>> out2 = expr(np.random.rand(9, 5), np.random.rand(5, 8))
+    >>> out2.shape
+    (8, 9)
+
+    >>> np.allclose(out1, out2)
+    False
+
+    >>> print(expr)
+    <ContractExpression('ij,[jk,kl,lm],mn->ni', constants=[1, 2, 3])>
+      1.  'jm,mn->jn' [GEMM]
+      2.  'jn,ij->ni' [GEMM]
+
+Where we can see that the expression now only has to perform
+two contractions to compute the output.
+
+.. note::
+
+    The constant part of an expression is lazily generated upon first call,
+    (with a particular backend) though it can be explicitly built with call to
+    :meth:`ContractExpression.parse_constants`.
+
+Even if there are no constant contractions to perform, it can be very
+advantageous to specify constant tensors for particular backends.
+For instance, if a GPU backend is used, the constant tensors will be kept on
+the device rather than being transfered each time.

--- a/opt_einsum/backends.py
+++ b/opt_einsum/backends.py
@@ -93,7 +93,7 @@ def build_tensorflow_expression(arrays, expr):
     return tensorflow_contract
 
 
-def parse_constants_tensorflow(const_arrays, expr):
+def evaluate_constants_tensorflow(const_arrays, expr):
     """Convert constant arguments to tensorflow constants, and perform any
     possible constant contractions. Requires evaluating a tensorflow graph.
     """
@@ -101,7 +101,7 @@ def parse_constants_tensorflow(const_arrays, expr):
 
     # compute the partial graph of new inputs
     const_arrays = [to_tensorflow(x, constant=True) for x in const_arrays]
-    new_ops, new_contraction_list = expr(*const_arrays, backend='tensorflow', parse_constants=True)
+    new_ops, new_contraction_list = expr(*const_arrays, backend='tensorflow', evaluate_constants=True)
 
     # evaluate the new inputs and convert to tensorflow constants
     session = tensorflow.get_default_session()
@@ -144,10 +144,10 @@ def build_theano_expression(arrays, expr):
     return theano_contract
 
 
-def parse_constants_theano(const_arrays, expr):
+def evaluate_constants_theano(const_arrays, expr):
     # compute the partial graph of new inputs
     const_arrays = [to_theano(x, constant=True) for x in const_arrays]
-    new_ops, new_contraction_list = expr(*const_arrays, backend='theano', parse_constants=True)
+    new_ops, new_contraction_list = expr(*const_arrays, backend='theano', evaluate_constants=True)
 
     # evaluate the new inputs and convert to theano shared tensors
     new_ops = [None if x is None else to_theano(x.eval(), constant=True) for x in new_ops]
@@ -178,12 +178,12 @@ def build_cupy_expression(_, expr):  # pragma: no cover
     return cupy_contract
 
 
-def parse_constants_cupy(const_arrays, expr):  # pragma: no cover
+def evaluate_constants_cupy(const_arrays, expr):  # pragma: no cover
     """Convert constant arguments to cupy arrays, and perform any possible
     constant contractions.
     """
     const_arrays = [to_cupy(x) for x in const_arrays]
-    return expr(*const_arrays, backend='cupy', parse_constants=True)
+    return expr(*const_arrays, backend='cupy', evaluate_constants=True)
 
 
 # Dispatch to correct expression backend
@@ -196,9 +196,9 @@ CONVERT_BACKENDS = {
 
 
 PARSE_CONSTS_BACKENDS = {
-    'tensorflow': parse_constants_tensorflow,
-    'theano': parse_constants_theano,
-    'cupy': parse_constants_cupy,
+    'tensorflow': evaluate_constants_tensorflow,
+    'theano': evaluate_constants_theano,
+    'cupy': evaluate_constants_cupy,
 }
 
 
@@ -209,7 +209,7 @@ def build_expression(backend, arrays, expr):
     return CONVERT_BACKENDS[backend](arrays, expr)
 
 
-def parse_constants(backend, arrays, expr):
+def evaluate_constants(backend, arrays, expr):
     """Convert constant arrays to the correct backend, and perform as much of
     the contraction of ``expr`` with these as possible.
     """

--- a/opt_einsum/backends.py
+++ b/opt_einsum/backends.py
@@ -82,7 +82,7 @@ def build_tensorflow_expression(arrays, expr):
     import tensorflow
 
     placeholders = [to_tensorflow(array) for array in arrays]
-    graph = expr._normal_contract(placeholders, backend='tensorflow')
+    graph = expr._contract(placeholders, backend='tensorflow')
 
     def tensorflow_contract(*arrays):
         session = tensorflow.get_default_session()
@@ -132,7 +132,7 @@ def build_theano_expression(arrays, expr):
     import theano
 
     in_vars = [to_theano(array) for array in arrays]
-    out_var = expr._normal_contract(in_vars, backend='theano')
+    out_var = expr._contract(in_vars, backend='theano')
 
     # don't supply constants to graph
     graph_ins = [x for x in in_vars if not isinstance(x, theano.tensor.TensorConstant)]
@@ -172,7 +172,7 @@ def build_cupy_expression(_, expr):  # pragma: no cover
 
     def cupy_contract(*arrays):
         cupy_arrays = [to_cupy(x) for x in arrays]
-        cupy_out = expr._normal_contract(cupy_arrays, backend='cupy')
+        cupy_out = expr._contract(cupy_arrays, backend='cupy')
         return cupy_out.get()
 
     return cupy_contract

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -402,7 +402,8 @@ def contract(*operands, **kwargs):
     use_blas = kwargs.pop('use_blas', True)
     memory_limit = kwargs.pop('memory_limit', None)
     backend = kwargs.pop('backend', 'numpy')
-    gen_expression = kwargs.pop('gen_expression', False)
+    gen_expression = kwargs.pop('_gen_expression', False)
+    constants_dict = kwargs.pop('_constants_dict', {})
 
     # Make sure remaining keywords are valid for einsum
     unknown_kwargs = [k for (k, v) in kwargs.items() if k not in valid_einsum_kwargs]
@@ -418,12 +419,12 @@ def contract(*operands, **kwargs):
 
     # check if performing contraction or just building expression
     if gen_expression:
-        return ContractExpression(full_str, contraction_list, **einsum_kwargs)
+        return ContractExpression(full_str, contraction_list, constants_dict, **einsum_kwargs)
 
     return _core_contract(operands, contraction_list, backend=backend, **einsum_kwargs)
 
 
-def _core_contract(operands, contraction_list, backend='numpy', **einsum_kwargs):
+def _core_contract(operands, contraction_list, backend='numpy', parse_constants=False, **einsum_kwargs):
     """Inner loop used to perform an actual contraction given the output
     from a ``contract_path(..., einsum_call=True)`` call.
     """
@@ -438,9 +439,15 @@ def _core_contract(operands, contraction_list, backend='numpy', **einsum_kwargs)
     # Start contraction loop
     for num, contraction in enumerate(contraction_list):
         inds, idx_rm, einsum_str, remaining, blas_flag = contraction
-        tmp_operands = []
-        for x in inds:
-            tmp_operands.append(operands.pop(x))
+
+        # check if we are performing the pre-pass of an expression with constants
+        if parse_constants:
+            # if so, keep contracting until we find any non-constant operators, then break out
+            operands_copy = list(operands)
+            if any(operands_copy.pop(x) is None for x in inds):
+                return operands, contraction_list[num:]
+
+        tmp_operands = [operands.pop(x) for x in inds]
 
         # Do we need to deal with the output?
         handle_out = specified_out and ((num + 1) == len(contraction_list))
@@ -452,9 +459,7 @@ def _core_contract(operands, contraction_list, backend='numpy', **einsum_kwargs)
             input_str, results_index = einsum_str.split('->')
             input_left, input_right = input_str.split(',')
 
-            tensor_result = input_left + input_right
-            for s in idx_rm:
-                tensor_result = tensor_result.replace(s, "")
+            tensor_result = "".join(s for s in input_left + input_right if s not in idx_rm)
 
             # Find indices to contract over
             left_pos, right_pos = [], []
@@ -483,7 +488,7 @@ def _core_contract(operands, contraction_list, backend='numpy', **einsum_kwargs)
             # Do the contraction
             new_view = _einsum(einsum_str, *tmp_operands, backend=backend, **einsum_kwargs)
 
-        # Append new items and derefernce what we can
+        # Append new items and dereference what we can
         operands.append(new_view)
         del tmp_operands, new_view
 
@@ -493,24 +498,53 @@ def _core_contract(operands, contraction_list, backend='numpy', **einsum_kwargs)
         return operands[0]
 
 
+def format_const_einsum_str(einsum_str, constants):
+    """Add brackets to the constant terms in ``einsum_str``. For example:
+
+        >>> format_const_einsum_str('ab,bc,cd->ad', [0, 2])
+        'bc,[ab,cd]->ad'
+    """
+    if "->" in einsum_str:
+        lhs, rhs = einsum_str.split('->')
+        arrow = "->"
+    else:
+        lhs, rhs, arrow = einsum_str, "", ""
+
+    ins, const_ins = [], []
+    for i, term in enumerate(lhs.split(',')):
+        (const_ins if i in constants else ins).append(term)
+
+    return "{},[{}]{}{}".format(','.join(ins), ','.join(const_ins), arrow, rhs)
+
+
 class ContractExpression:
     """Helper class for storing an explicit ``contraction_list`` which can
     then be repeatedly called solely with the array arguments.
     """
 
-    def __init__(self, contraction, contraction_list, **einsum_kwargs):
+    def __init__(self, contraction, contraction_list, constants_dict, **einsum_kwargs):
         self.contraction = contraction
         self.contraction_list = contraction_list
         self.einsum_kwargs = einsum_kwargs
-        self.num_args = len(contraction.split('->')[0].split(','))
+        self.num_args = len(contraction_list[0][0]) + len(contraction_list[0][3]) - 1
+        self.constants = None
 
-    def _normal_contract(self, arrays, out=None, backend='numpy'):
+        # perform as much of the contraction as possible if constants supplied
+        if constants_dict:
+            tmp_const_ops = [constants_dict.get(i, None) for i in range(self.num_args)]
+            new_ops, new_contraction_list = self(*tmp_const_ops, parse_constants=True)
+            self.contraction = format_const_einsum_str(contraction, constants_dict.keys())
+            self.num_args -= len(constants_dict)
+            self.contraction_list = new_contraction_list
+            self.constants = new_ops
+
+    def _normal_contract(self, arrays, out=None, backend='numpy', parse_constants=False):
         """The normal, core contraction.
         """
-        return _core_contract(list(arrays), self.contraction_list, out=out,
-                              backend=backend, **self.einsum_kwargs)
+        return _core_contract(list(arrays), self.contraction_list, out=out, backend=backend,
+                              parse_constants=parse_constants, **self.einsum_kwargs)
 
-    def _convert_contract(self, arrays, out, backend):
+    def _convert_contract(self, arrays, out, backend, parse_constants=False):
         """Special contraction, i.e. contraction with a different backend
         but converting to and from that backend. Checks for
         ``self._{backend}_contract``, generates it if is missing, then calls it
@@ -543,24 +577,29 @@ class ContractExpression:
             are supplied then try to convert them to and from the correct
             backend array type.
         """
-
         if len(arrays) != self.num_args:
             raise ValueError("This `ContractExpression` takes exactly %s array arguments "
                              "but received %s." % (self.num_args, len(arrays)))
 
-        backend = kwargs.pop('backend', 'numpy')
         out = kwargs.pop('out', None)
+        backend = kwargs.pop('backend', 'numpy')
+        parse_constants = kwargs.pop('parse_constants', False)
         if kwargs:
             raise ValueError("The only valid keyword arguments to a `ContractExpression` "
                              "call are `out=` or `backend=`. Got: %s." % kwargs)
+
+        if self.constants:
+            # fill in the missing non-constant terms with newly supplied arrays
+            arrays = iter(arrays)
+            arrays = [next(arrays) if op is None else op for op in self.constants]
 
         try:
             # Check if the backend requires special preparation / calling
             #   but also ignore non-numpy arrays -> assume user wants same type back
             if backend in backends.CONVERT_BACKENDS and isinstance(arrays[0], np.ndarray):
-                return self._convert_contract(arrays, out, backend)
+                return self._convert_contract(arrays, out, backend, parse_constants=parse_constants)
 
-            return self._normal_contract(arrays, out, backend)
+            return self._normal_contract(arrays, out, backend, parse_constants=parse_constants)
 
         except ValueError as err:
             original_msg = str(err.args) if err.args else ""
@@ -602,6 +641,9 @@ def contract_expression(subscripts, *shapes, **kwargs):
         Specifies the subscripts for summation.
     shapes : sequence of integer tuples
         Shapes of the arrays to optimize the contraction for.
+    constants : sequence of int, optional
+        The indices of any constant arguments, in which case the actual array
+        should be supplied at that position rather than just a shape.
     kwargs :
         Passed on to ``contract_path`` or ``einsum``. See ``contract``.
 
@@ -640,6 +682,14 @@ def contract_expression(subscripts, *shapes, **kwargs):
             raise ValueError("'%s' should only be specified when calling a "
                              "`ContractExpression`, not when building it." % arg)
 
-    dummy_arrays = [_ShapeOnly(s) for s in shapes]
+    kwargs['_gen_expression'] = True
 
-    return contract(subscripts, *dummy_arrays, gen_expression=True, **kwargs)
+    # build dict of constant indices mapped to arrays
+    constants = kwargs.pop('constants', ())
+    constants_dict = {i: shapes[i] for i in constants}
+    kwargs['_constants_dict'] = constants_dict
+
+    # apart from constant arguements, make dummy arrays
+    dummy_arrays = [s if i in constants else _ShapeOnly(s) for i, s in enumerate(shapes)]
+
+    return contract(subscripts, *dummy_arrays, **kwargs)

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -545,7 +545,7 @@ class ContractExpression:
         self._parsed_constants = {}
         self._backend_expressions = {}
 
-    def parse_constants(self, backend):
+    def parse_constants(self, backend='numpy'):
         """Convert any constant operands to the correct backend form, and
         perform as many contractions as possible to create a new list of
         operands, stored in ``self._parsed_constants[backend]``. This also

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -644,7 +644,7 @@ class ContractExpression:
         try:
             # Check if the backend requires special preparation / calling
             #   but also ignore non-numpy arrays -> assume user wants same type back
-            if backend in backends.CONVERT_BACKENDS and isinstance(arrays[0], np.ndarray):
+            if backend in backends.CONVERT_BACKENDS and any(isinstance(x, np.ndarray) for x in arrays):
                 return self._contract_with_conversion(ops, out, backend, parse_constants=parse_constants)
 
             return self._contract(ops, out, backend, parse_constants=parse_constants)

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -440,12 +440,10 @@ def _core_contract(operands, contraction_list, backend='numpy', evaluate_constan
     for num, contraction in enumerate(contraction_list):
         inds, idx_rm, einsum_str, remaining, blas_flag = contraction
 
-        # check if we are performing the pre-pass of an expression with constants
-        if evaluate_constants:
-            # if so, keep contracting until we find any non-constant operators, then break out
-            operands_copy = list(operands)
-            if any(operands_copy.pop(x) is None for x in inds):
-                return operands, contraction_list[num:]
+        # check if we are performing the pre-pass of an expression with constants,
+        #     if so, break out upon finding first non-constant (None) operand
+        if evaluate_constants and any(operands[x] is None for x in inds):
+            return operands, contraction_list[num:]
 
         tmp_operands = [operands.pop(x) for x in inds]
 

--- a/opt_einsum/tests/test_backends.py
+++ b/opt_einsum/tests/test_backends.py
@@ -83,7 +83,7 @@ def test_tensorflow_with_constants():
     # check tensorflow
     with sess.as_default():
         res_got = expr(var, backend='tensorflow')
-    assert 'tensorflow' in expr._parsed_constants
+    assert 'tensorflow' in expr._evaluated_constants
     assert np.allclose(res_exp, res_got)
 
     # check can call with numpy still
@@ -127,7 +127,7 @@ def test_theano_with_constants():
 
     # check theano
     res_got = expr(var, backend='theano')
-    assert 'theano' in expr._parsed_constants
+    assert 'theano' in expr._evaluated_constants
     assert np.allclose(res_exp, res_got)
 
     # check can call with numpy still
@@ -172,7 +172,7 @@ def test_cupy_with_constants():
 
     # check cupy
     res_got = expr(var, backend='cupy')
-    assert 'cupy' in expr._parsed_constants
+    assert 'cupy' in expr._evaluated_constants
     assert np.allclose(res_exp, res_got)
 
     # check can call with numpy still

--- a/opt_einsum/tests/test_contract.py
+++ b/opt_einsum/tests/test_contract.py
@@ -205,3 +205,31 @@ def test_contract_expressions(string, optimize, use_blas, out_spec):
     assert string in expr.__repr__()
     assert string in expr.__str__()
 
+
+@pytest.mark.parametrize("string,constants", [
+    ('hbc,bdef,cdkj,ji,ikeh,lfo', [1, 2, 3, 4]),
+    ('bdef,cdkj,ji,ikeh,hbc,lfo', [0, 1, 2, 3]),
+    ('hbc,bdef,cdkj,ji,ikeh,lfo', [1, 2, 3, 4]),
+    ('hbc,bdef,cdkj,ji,ikeh,lfo', [1, 2, 3, 4]),
+    ('ijab,acd,bce,df,ef->ji', [1, 2, 3, 4]),
+    ('ab,cd,ad,cb', [1, 3]),
+    ('ab,bc,cd', [0, 1]),
+])
+def test_contract_expression_with_constants(string, constants):
+    views = helpers.build_views(string)
+    expected = contract(string, *views, optimize=False, use_blas=False)
+
+    shapes = [view.shape for view in views]
+
+    expr_args = []
+    ctrc_args = []
+    for i, (shape, view) in enumerate(zip(shapes, views)):
+        if i in constants:
+            expr_args.append(view)
+        else:
+            expr_args.append(shape)
+            ctrc_args.append(view)
+
+    expr = contract_expression(string, *expr_args, constants=constants)
+    out = expr(*ctrc_args)
+    assert np.allclose(expected, out)


### PR DESCRIPTION
This allows constant tensors to be supplied to ``contract_expression``, which will then build as many constant intermediaries as it can. Still a bit of a work in progress but the core functionality is working so thought I'd share. Resolves #7.

## Example
Basic setup:
```python
>>> from opt_einsum import contract_expression
>>> from numpy.random import rand

>>> equation = 'ij,jk,kl,lm,mn->ni'
>>> const_ops = rand(2, 2), rand(2, 2), rand(2, 2)
>>> ops = (3, 2), *const_ops, (2, 3)  # non-const ops are just shapes

>>> expr = contract_expression(equation, *ops, constants=[1, 2, 3])
>>> expr
ContractExpression('ij,mn,[jk,kl,lm]->ni')

>>> print(expr)
<ContractExpression> for 'ij,mn,[jk,kl,lm]->ni':
  1.  'jm,ij->mi' [GEMM]
  2.  'mi,mn->ni' [GEMM]
```
Now we can call it with just two arrays:
```python
>>> expr(rand(3, 2), rand(2, 3))
array([[0.10982582, 0.06334146, 0.09379349],
       [0.09159049, 0.05282374, 0.07821902],
       [0.15775775, 0.09097925, 0.13471551]])

>>> expr(rand(3, 2), rand(2, 3))
array([[0.19207156, 0.21354127, 0.04811443],
       [0.01633236, 0.01815862, 0.004091  ],
       [0.06079124, 0.06758219, 0.0152304 ]])
```

## Notes
* Currently this just performs as many contractions in the ``contraction_list`` as possible, stopping when it reaches a non-constant array. This means that some potential constant contractions might still be missed even though they don't depend on anything (e.g. ``'a,a,b,b'`` with ``constants=[0, 1]`` might still choose to contract ``b,b`` first). One solution would be to somehow reshuffle the ``contraction_list`` but this gets a bit messy.
* How do we feel about the ``repr``?

## TODO
- [x] ~~Sort out interaction with ``backend`` (need to not cache expression on first constants pass, and deal with various conversion points (e.g. keep constants on GPU)~~
- [x] Document
- [ ] Add edge case tests? Additional errors to help user?