### PR TITLE
DOC: drop in replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Optimized Einsum: A tensor contraction order optimizer
 
 Optimized einsum can greatly reduce the overall time `np.einsum` takes by optimizing the expressions contraction order and dispatching many operations to canonical BLAS routines. See the [documention](http://optimized-einsum.readthedocs.io) for more information.
 
+`opt_einsum.contract` is a drop-in replacement for `np.einsum`.
+
 ## Quick tutorial
 Einsum is a very powerful function for contracting tensors of arbitrary dimension and index.
 However, it is only optimized to contract two terms at a time resulting in non-optimal scaling.

--- a/opt_einsum/tests/test_contract.py
+++ b/opt_einsum/tests/test_contract.py
@@ -110,6 +110,13 @@ def test_compare(string):
     assert np.allclose(ein, opt)
 
 
+@pytest.mark.parametrize("string", tests)
+def test_drop_in_replacement(string):
+    views = helpers.build_views(string)
+    opt = contract(string, *views)
+    assert np.allclose(opt, np.einsum(string, *views))
+
+
 @pytest.mark.skipif(sys.version_info[0] < 3, reason='requires python3')
 @pytest.mark.parametrize("string", tests)
 def test_compare_greek(string):


### PR DESCRIPTION

This PR documents and tests the fact that `opt_einsum.contract` is a drop in for `np.einsum`.
