### PR TITLE
CI: Switches to conda for environment testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,31 +11,33 @@ matrix:
     - python: 3.4
     - python: 3.5
     - python: 3.6
+    - python: 3.7
+
+  allow_failures:
+    - python: 3.7
 
 before_install:
+  # Additional info about the build
   - uname -a
   - free -m
   - df -h
   - ulimit -a
   - python -V
-  - pip install --upgrade pip setuptools
-  - pip install pytest pytest-cov codecov
-  - pip install numpy
-  - pip install codecov
-  - pip install tensorflow
-  - pip install theano
-  - pip install dask[array]
-  - pip install sparse
-  - pip install -e .
-  - if [ `python -c "import numpy; print(numpy.version.version)"` == "1.14.0" ]; then
-        pip install numpy --upgrade;
-    fi
+
+  # Setup python environment
+  - source devtools/travis-ci/before_install.sh
+  - python -V
+
+install:
+    # Install from environment
+  - conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/full_test.yaml
+  - source activate test
+
+    # Build and install package
+  - python setup.py develop --no-deps
 
 script:
-  - py.test -v --cov=./
-
-# after_success:
-#   - ./tools/travis-upload-wheel.sh
+  - py.test -v --cov=opt_einsum opt_einsum/
 
 notifications:
     email: false

--- a/devtools/conda-envs/full_test.yaml
+++ b/devtools/conda-envs/full_test.yaml
@@ -10,6 +10,7 @@ dependencies:
   - tensorflow
   - dask
   - sparse
+  - theano
 
     # Testing
   - pytest

--- a/devtools/conda-envs/full_test.yaml
+++ b/devtools/conda-envs/full_test.yaml
@@ -1,0 +1,16 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+    # Base depends
+  - numpy
+
+    # Backends
+  - tensorflow
+  - dask
+  - sparse
+
+    # Testing
+  - pytest
+  - codecov
+  - pytest-cov

--- a/devtools/conda-envs/full_test.yaml
+++ b/devtools/conda-envs/full_test.yaml
@@ -4,6 +4,7 @@ channels:
 dependencies:
     # Base depends
   - numpy
+  - nomkl
 
     # Backends
   - tensorflow

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -1,0 +1,34 @@
+# Temporarily change directory to $HOME to install software
+pushd .
+cd $HOME
+
+# Install Miniconda
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    # Make OSX md5 mimic md5sum from linux, alias does not work
+    md5sum () {
+        command md5 -r "$@"
+    }
+    MINICONDA=Miniconda3-latest-MacOSX-x86_64.sh
+else
+    MINICONDA=Miniconda3-latest-Linux-x86_64.sh
+    export PYTHON_VER=$TRAVIS_PYTHON_VERSION
+fi
+MINICONDA_HOME=$HOME/miniconda
+MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+wget -q https://repo.continuum.io/miniconda/$MINICONDA
+if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
+    echo "Miniconda MD5 mismatch"
+    exit 1
+fi
+bash $MINICONDA -b -p $MINICONDA_HOME
+
+# Configure miniconda
+export PIP_ARGS="-U"
+export PATH=$MINICONDA_HOME/bin:$PATH
+    
+conda config --add channels conda-forge
+conda config --set always_yes yes --set changeps1 no
+conda update --q conda
+
+# Restore original directory
+popd


### PR DESCRIPTION
## Description
Switches testing to `conda` as the backend install are increasingly more compilation dependent.

## Questions
@jcmgray Do you have a conda caching example, historically this has given me quite a bit of trouble.

## Status
- [x] Ready to go