### PR TITLE
'auto' path mode + test coverage

### DIFF
--- a/opt_einsum/helpers.py
+++ b/opt_einsum/helpers.py
@@ -117,7 +117,8 @@ def find_contraction(positions, input_sets, output_set):
     """
 
     remaining = list(input_sets)
-    idx_contract = set.union(*map(remaining.pop, sorted(positions, reverse=True)))
+    inputs = (remaining.pop(i) for i in sorted(positions, reverse=True))
+    idx_contract = set.union(*inputs)
     idx_remain = output_set.union(*remaining)
 
     new_result = idx_remain & idx_contract

--- a/opt_einsum/helpers.py
+++ b/opt_einsum/helpers.py
@@ -117,11 +117,7 @@ def find_contraction(positions, input_sets, output_set):
     """
 
     remaining = list(input_sets)
-    idx_contract = set()
-
-    for i in sorted(positions, reverse=True):
-        idx_contract |= remaining.pop(i)
-
+    idx_contract = set.union(*map(remaining.pop, sorted(positions, reverse=True)))
     idx_remain = output_set.union(*remaining)
 
     new_result = idx_remain & idx_contract

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -216,11 +216,6 @@ def greedy(input_sets, output_set, idx_dict, memory_limit):
     [(0, 2), (0, 1)]
     """
 
-    if len(input_sets) == 1:
-        return [(0, )]
-    elif len(input_sets) == 2:
-        return [(0, 1)]
-
     # Build up a naive cost
     contract = helpers.find_contraction(range(len(input_sets)), input_sets, output_set)
     idx_result, new_input_sets, idx_removed, idx_contract = contract

--- a/opt_einsum/tests/test_backends.py
+++ b/opt_einsum/tests/test_backends.py
@@ -30,6 +30,7 @@ tests = [
     'ab,bc->ca',
     'abc,bcd,dea',
     'abc,def->fedcba',
+    'abc,bcd,df->fa',
     # test 'prefer einsum' ops
     'ijk,ikj',
     'i,j->ij',

--- a/opt_einsum/tests/test_contract.py
+++ b/opt_einsum/tests/test_contract.py
@@ -231,5 +231,6 @@ def test_contract_expression_with_constants(string, constants):
             ctrc_args.append(view)
 
     expr = contract_expression(string, *expr_args, constants=constants)
+    print(expr)
     out = expr(*ctrc_args)
     assert np.allclose(expected, out)

--- a/opt_einsum/tests/test_input.py
+++ b/opt_einsum/tests/test_input.py
@@ -2,6 +2,8 @@
 Tests the input parsing for opt_einsum. Duplicates the np.einsum input tests.
 """
 
+import sys
+
 import numpy as np
 import pytest
 
@@ -226,3 +228,12 @@ def test_singleton_dimension_broadcast():
         res2 = contract("...ij,...jk->...ik", p, q, optimize=optimize)
         assert np.allclose(res1, res2)
         assert np.allclose(res2, np.full((1, 5), 5))
+
+
+@pytest.mark.skipif(sys.version_info.major == 2, reason="Requires python 3.")
+def test_large_int_input_format():
+    string = 'ab,bc,cd'
+    x, y, z = build_views(string)
+    string_output = contract(string, x, y, z)
+    int_output = contract(x, (1000, 1001), y, (1001, 1002), z, (1002, 1003))
+    assert np.allclose(string_output, int_output)


### PR DESCRIPTION
## Description
* Enables 'auto' mode as the default contraction path. This uses the optimal path for 4 or less operators, but otherwise the greedy path - @dgasmith not sure if you were also about to add 'auto' mode (in which case I can remove).

* A few other tweaks that up the test coverage a bit.


## Status
- [x] Ready to go