### PR TITLE
Rename symbols to support torch.einsum

### DIFF
--- a/opt_einsum/backends/torch.py
+++ b/opt_einsum/backends/torch.py
@@ -5,8 +5,7 @@ Required functions for optimized contractions of numpy arrays using pytorch.
 from __future__ import absolute_import
 import numpy as np
 
-from ..parser import einsum_symbols_base, get_symbol
-
+from ..parser import convert_to_valid_einsum_chars, einsum_symbols_base
 
 _TORCH_DEVICE = None
 
@@ -33,9 +32,7 @@ def einsum(equation, *operands):
     """
     # rename symbols to support PyTorch 0.4.1 and earlier,
     # which allow only symbols a-z.
-    symbols = sorted(set(equation) - set(',->'))
-    rename = {s: get_symbol(i) for i, s in enumerate(symbols)}
-    equation = ''.join(rename.get(s, s) for s in equation)
+    equation = convert_to_valid_einsum_chars(equation)
 
     torch, _ = _get_torch_and_device()
     return torch.einsum(equation, operands)

--- a/opt_einsum/helpers.py
+++ b/opt_einsum/helpers.py
@@ -4,8 +4,8 @@ Contains helper functions for opt_einsum testing scripts
 
 import numpy as np
 
-chars = 'abcdefghijklmopq'
-sizes = np.array([2, 3, 4, 5, 4, 3, 2, 6, 5, 4, 3, 2, 5, 7, 4, 3])
+chars = 'abcdefghijklmopqABC'
+sizes = np.array([2, 3, 4, 5, 4, 3, 2, 6, 5, 4, 3, 2, 5, 7, 4, 3, 2, 3, 4])
 default_dim_dict = {c: s for c, s in zip(chars, sizes)}
 
 

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -57,18 +57,11 @@ def gen_unused_symbols(used, n):
 
 def convert_to_valid_einsum_chars(einsum_str):
     """Convert the str ``einsum_str`` to contain only the alphabetic characters
-    valid for numpy einsum.
+    valid for numpy einsum. If there are too many symbols, let the backend
+    throw an error.
     """
-    # partition into valid and invalid sets
-    valid, invalid = set(), set()
-    for x in einsum_str:
-        (valid if is_valid_einsum_char(x) else invalid).add(x)
-
-    # get replacements for invalid chars that are not already used
-    available = gen_unused_symbols(valid, len(invalid))
-
-    # map invalid to available and replace in the inputs
-    replacer = dict(zip(invalid, available))
+    symbols = sorted(set(einsum_str) - set(',->'))
+    replacer = {x: get_symbol(i) for i, x in enumerate(symbols)}
     return "".join(replacer.get(x, x) for x in einsum_str)
 
 

--- a/opt_einsum/tests/test_backends.py
+++ b/opt_einsum/tests/test_backends.py
@@ -35,6 +35,7 @@ tests = [
     'ijk,ikj',
     'i,j->ij',
     'ijk,k->ij',
+    'AB,BC->CA',
 ]
 
 


### PR DESCRIPTION
## Description
This renames symbols to support PyTorch 0.4.1 which supports only symbols a-z. This is useful when the overall computation has more than 26 dimensions but any single contraction requires only 26 or fewer dimensions.

## Questions
- [x] Do other backends work? I have only tested PyTorch. If other backends don't work, I'll simply limit the test to the PyTorch backend.

## Status
- [x] Ready to merge as soon as tests pass

## Tested

- Added a test with non-lowercase symbols
- Tested that this works in an application using Pyro https://github.com/uber/pyro/pull/1313