### PR TITLE
Avoid unicode in README.md; avoid failing in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ True
 1 loops, best of 3: 934 ms per loop
 
 %timeit optimized(I, C)
-1000 loops, best of 3: 527 µs per loop
+1000 loops, best of 3: 527 us per loop
 ```
 
 A 2000 fold speed up for 4 extra lines of code!
@@ -70,7 +70,7 @@ The opt_einsum package is a drop-in replacement for the np.einsum function and c
 from opt_einsum import contract
 
 %timeit contract('pi,qj,ijkl,rk,sl->pqrs', C, C, I, C, C)
-1000 loops, best of 3: 324 µs per loop
+1000 loops, best of 3: 324 us per loop
 ```
 
 The above will automatically find the optimal contraction order, in this case, identical to that of the optimized function above, and compute the products for you. In this case, it even uses `np.dot` under the hood to exploit any vendor BLAS functionality that your NumPy build has!

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,20 @@
 import setuptools
 import versioneer
 
-with open("README.md", "r") as handle:
-    long_description = handle.read()
+short_description = "Optimizing numpys einsum function"
+try:
+    with open("README.md", "r") as handle:
+        long_description = handle.read()
+except:
+    long_description = short_description
+
 
 if __name__ == "__main__":
     setuptools.setup(
         name='opt_einsum',
         version=versioneer.get_version(),
         cmdclass=versioneer.get_cmdclass(),
-        description='Optimizing numpys einsum function',
+        description=short_description,
         author='Daniel Smith',
         author_email='dgasmith@icloud.com',
         url="https://github.com/dgasmith/opt_einsum",


### PR DESCRIPTION
## Description
This attempts to fix an error reported by @martinjankowiak when pip installing `opt_einsum` in Python 3.6:
```
Complete output from command python setup.py egg_info:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/pip-build-09n_lk1q/opt-einsum/setup.py", line 7, in <module>
    long_description = handle.read()
  File "/opt/conda/envs/pytorch-py3.6/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 3749: ordinal not in range(128)
```
I haven't been able to reproduce the error, but it appears to be due to failure to parse the letter μ. I've
1. replace 'μ' with 'u', and
2. embedded the `long_description` parsing in a try-except to avoid blocking installation by silly errors in the future.

## Status
- [x] Ready to go