### PR TITLE
make shared_intermediates thread-safe

### DIFF
--- a/opt_einsum/tests/test_sharing.py
+++ b/opt_einsum/tests/test_sharing.py
@@ -6,11 +6,11 @@ import numpy as np
 import pytest
 
 from opt_einsum import (contract_expression, contract_path, get_symbol,
-                        helpers, shared_intermediates)
+                        contract, helpers, shared_intermediates)
 from opt_einsum.backends import to_cupy, to_torch
 from opt_einsum.contract import _einsum
 from opt_einsum.parser import parse_einsum_input
-from opt_einsum.sharing import count_cached_ops
+from opt_einsum.sharing import count_cached_ops, currently_sharing, get_sharing_cache
 
 try:
     import cupy
@@ -362,3 +362,23 @@ def test_chain_sharing(size, backend):
     print('Without sharing: {} expressions'.format(num_exprs_nosharing))
     print('With sharing: {} expressions'.format(num_exprs_sharing))
     assert num_exprs_nosharing > num_exprs_sharing
+
+
+def test_multithreaded_sharing():
+    from multiprocessing.pool import ThreadPool
+
+    def fn():
+        X, Y, Z = helpers.build_views('ab,bc,cd')
+
+        with shared_intermediates():
+            contract('ab,bc,cd->a', X, Y, Z)
+            contract('ab,bc,cd->b', X, Y, Z)
+
+            return len(get_sharing_cache())
+
+    expected = fn()
+    pool = ThreadPool(8)
+    fs = [pool.apply_async(fn) for _ in range(16)]
+    assert not currently_sharing()
+    assert [f.get() for f in fs] == [expected] * 16
+    pool.close()


### PR DESCRIPTION
## Description
Makes ``shared_intermediates`` thread safe, by storing the caches in a dict referenced by thread id. All threads can (still) share the same cache among themselves, if it is supplied to them all. Resolves #51. cc @fritzo.

## Todos
  - [x] Implement a python2/3 compatible test

## Status
- [x] Ready to go