### PR TITLE
allow sharing for tensorflow and theano as numpy backends

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,10 @@ dimension and index. However, it is only optimized to contract two terms
 at a time resulting in non-optimal scaling.
 
 For example, consider the following index transformation:
-``M_{pqrs} = C_{pi} C_{qj} I_{ijkl} C_{rk} C_{sl}``
+
+.. math::
+
+    M_{pqrs} = C_{pi} C_{qj} I_{ijkl} C_{rk} C_{sl}
 
 Consider two different algorithms:
 

--- a/opt_einsum/backends/tensorflow.py
+++ b/opt_einsum/backends/tensorflow.py
@@ -6,7 +6,10 @@ from __future__ import absolute_import
 
 import numpy as np
 
+from ..sharing import to_backend_cache_wrap
+
 __all__ = ["to_tensorflow", "build_expression", "evaluate_constants"]
+
 
 _CACHED_TF_DEVICE = None
 
@@ -31,6 +34,7 @@ def _get_tensorflow_and_device():
     return _CACHED_TF_DEVICE
 
 
+@to_backend_cache_wrap(constants=True)
 def to_tensorflow(array, constant=False):
     """Convert a numpy array to a ``tensorflow.placeholder`` instance.
     """

--- a/opt_einsum/backends/theano.py
+++ b/opt_einsum/backends/theano.py
@@ -6,9 +6,12 @@ from __future__ import absolute_import
 
 import numpy as np
 
+from ..sharing import to_backend_cache_wrap
+
 __all__ = ["to_theano", "build_expression", "evaluate_constants"]
 
 
+@to_backend_cache_wrap(constants=True)
 def to_theano(array, constant=False):
     """Convert a numpy array to ``theano.tensor.TensorType`` instance.
     """

--- a/opt_einsum/sharing.py
+++ b/opt_einsum/sharing.py
@@ -180,18 +180,34 @@ def einsum_cache_wrap(einsum):
     return cached_einsum
 
 
-def to_backend_cache_wrap(to_backend):
+def to_backend_cache_wrap(to_backend=None, constants=False):
     """Decorates an ``to_backend()`` implementation to be memoized inside a
     :func:`shared_intermediates` context (e.g. ``to_cupy``, ``to_torch``).
     """
+    # manage the case that decorator is called with args
+    if to_backend is None:
+        return functools.partial(to_backend_cache_wrap, constants=constants)
 
-    @functools.wraps(to_backend)
-    def cached_to_backend(array):
-        if not currently_sharing():
-            return to_backend(array)
+    if constants:
 
-        # hash by id
-        key = to_backend.__name__, id(array)
-        return _memoize(key, to_backend, array)
+        @functools.wraps(to_backend)
+        def cached_to_backend(array, constant=False):
+            if not currently_sharing():
+                return to_backend(array, constant=constant)
+
+            # hash by id
+            key = to_backend.__name__, id(array), constant
+            return _memoize(key, to_backend, array)
+
+    else:
+
+        @functools.wraps(to_backend)
+        def cached_to_backend(array):
+            if not currently_sharing():
+                return to_backend(array)
+
+            # hash by id
+            key = to_backend.__name__, id(array)
+            return _memoize(key, to_backend, array)
 
     return cached_to_backend


### PR DESCRIPTION
## Description
Allows sharing to be used with tensorflow and theano as numpy backends. Closes #50. The ``to_{backend}`` functions are all called internally within their respective ``{backend.py}`` submodules so I didn't try and factorize out a new ``to_backend`` function. I think it will be pretty easy (and rare) to add new conversion backends anyway. Also the tests are in ``test_backends.py`` rather than ``test_sharing.py`` just because the tensorflow tests require a ``session``, and the theano tests can't use ``einsum`` itself. 

## Status
- [x] Ready to go