### PR TITLE
Add prototype cheap optimizer

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -11,5 +11,6 @@ Function Reference
     opt_einsum.contract.ContractExpression
     opt_einsum.paths.optimal
     opt_einsum.paths.greedy
+    opt_einsum.paths.cheap
     opt_einsum.parser.get_symbol
     opt_einsum.sharing.shared_intermediates

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -11,6 +11,6 @@ Function Reference
     opt_einsum.contract.ContractExpression
     opt_einsum.paths.optimal
     opt_einsum.paths.greedy
-    opt_einsum.paths.cheap
+    opt_einsum.paths.eager
     opt_einsum.parser.get_symbol
     opt_einsum.sharing.shared_intermediates

--- a/docs/source/eager_path.rst
+++ b/docs/source/eager_path.rst
@@ -1,0 +1,12 @@
+==============
+The Eager Path
+==============
+
+The ``eager`` path is constructed in three stages:
+1. Eagerly compute Hadamard products (in arbitrary order -- this is commutative).
+2. Greedily contract pairs of remaining tensors, at each step choosing the pair that minimizes ``result_size - sum(input_sizes) / 2``.
+3. Greedily compute pairwise outer products, at each step choosing the pair that minimizes ``sum(input_sizes)``.
+
+The ``eager`` has space and time complexity ``O(n * k)`` where ``n`` is the number of tensors and ``k`` is the maximum number of tensors that share any dimension (excluding dimensions that occurr in the output or in every tensor).
+This algorithm this scales well to very large sparse contractions of small tensors.
+The ``eager`` functionality is provided by :func:`~opt_einsum.paths.eager`.

--- a/docs/source/eager_path.rst
+++ b/docs/source/eager_path.rst
@@ -3,10 +3,11 @@ The Eager Path
 ==============
 
 The ``eager`` path is constructed in three stages:
+
 1. Eagerly compute Hadamard products (in arbitrary order -- this is commutative).
 2. Greedily contract pairs of remaining tensors, at each step choosing the pair that minimizes ``result_size - sum(input_sizes) / 2``.
 3. Greedily compute pairwise outer products, at each step choosing the pair that minimizes ``sum(input_sizes)``.
 
-The ``eager`` has space and time complexity ``O(n * k)`` where ``n`` is the number of tensors and ``k`` is the maximum number of tensors that share any dimension (excluding dimensions that occurr in the output or in every tensor).
+The ``eager`` algorithm has space and time complexity ``O(n * k)`` where ``n`` is the number of input tensors and ``k`` is the maximum number of tensors that share any dimension (excluding dimensions that occurr in the output or in every tensor).
 This algorithm this scales well to very large sparse contractions of small tensors.
 The ``eager`` functionality is provided by :func:`~opt_einsum.paths.eager`.

--- a/docs/source/eager_path.rst
+++ b/docs/source/eager_path.rst
@@ -5,7 +5,7 @@ The Eager Path
 The ``eager`` path is constructed in three stages:
 
 1. Eagerly compute Hadamard products (in arbitrary order -- this is commutative).
-2. Greedily contract pairs of remaining tensors, at each step choosing the pair that minimizes ``result_size - sum(input_sizes) / 2``.
+2. Greedily contract pairs of remaining tensors, at each step choosing the pair that maximizes ``reduced_size``.
 3. Greedily compute pairwise outer products, at each step choosing the pair that minimizes ``sum(input_sizes)``.
 
 The ``eager`` algorithm has space and time complexity ``O(n * k)`` where ``n`` is the number of input tensors and ``k`` is the maximum number of tensors that share any dimension (excluding dimensions that occurr in the output or in every tensor).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -134,6 +134,7 @@ Table of Contents
    path_finding
    optimal_path
    greedy_path
+   eager_path
 
 .. toctree::
    :maxdepth: 1

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -99,7 +99,7 @@ def contract_path(*operands, **kwargs):
         - 'optimal' An algorithm that tries all possible ways of
           contracting the listed tensors. Scales exponentially with
           the number of terms in the contraction.
-        - 'cheap' An approximate algorithm that is cheaper than 'greedy' for
+        - 'eager' An approximate algorithm that is cheaper than 'greedy' for
           very large contractions.
         - 'auto' Use the optimal approach for a small number of terms (currently
           4 or less), else use the greedy approach.
@@ -255,8 +255,8 @@ def contract_path(*operands, **kwargs):
         path = paths.optimal(input_sets, output_set, dimension_dict, memory_arg)
     elif path_type in ("greedy", "opportunistic", "auto"):
         path = paths.greedy(input_sets, output_set, dimension_dict, memory_arg)
-    elif path_type == 'cheap':
-        path = paths.cheap(input_sets, output_set, dimension_dict)
+    elif path_type == 'eager':
+        path = paths.eager(input_sets, output_set, dimension_dict)
     else:
         raise KeyError("Path name '{}' not found".format(path_type))
 
@@ -394,7 +394,7 @@ def contract(*operands, **kwargs):
         - 'optimal' An algorithm that tries all possible ways of
           contracting the listed tensors. Scales exponentially with
           the number of terms in the contraction.
-        - 'cheap' An approximate algorithm that is cheaper than 'greedy'
+        - 'eager' An approximate algorithm that is cheaper than 'greedy'
           for very large contractions.
 
     memory_limit : {None, int, 'max_input'} (default: None)

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -42,23 +42,23 @@ class PathInfo(object):
         header = ("scaling", "BLAS", "current", "remaining")
 
         path_print = [
-            "  Complete contraction:  {}\n".format(overall_contraction),
-            "         Naive scaling:  {}\n".format(len(self.indices)),
-            "     Optimized scaling:  {}\n".format(max(self.scale_list)),
-            "      Naive FLOP count:  {:.3e}\n".format(naive_cost),
-            "  Optimized FLOP count:  {:.3e}\n".format(opt_cost),
-            "   Theoretical speedup:  {:3.3f}\n".format(speedup),
-            "  Largest intermediate:  {:.3e} elements\n".format(largest_intermediate),
-            "-" * 80 + "\n",
-            "{:>6} {:>11} {:>22} {:>37}\n".format(*header),
-            "-" * 80
+            u"  Complete contraction:  {}\n".format(overall_contraction),
+            u"         Naive scaling:  {}\n".format(len(self.indices)),
+            u"     Optimized scaling:  {}\n".format(max(self.scale_list)),
+            u"      Naive FLOP count:  {:.3e}\n".format(naive_cost),
+            u"  Optimized FLOP count:  {:.3e}\n".format(opt_cost),
+            u"   Theoretical speedup:  {:3.3f}\n".format(speedup),
+            u"  Largest intermediate:  {:.3e} elements\n".format(largest_intermediate),
+            u"-" * 80 + "\n",
+            u"{:>6} {:>11} {:>22} {:>37}\n".format(*header),
+            u"-" * 80
         ]
 
         for n, contraction in enumerate(self.contraction_list):
             inds, idx_rm, einsum_str, remaining, do_blas = contraction
             remaining_str = ",".join(remaining) + "->" + self.output_subscript
             path_run = (self.scale_list[n], do_blas, einsum_str, remaining_str)
-            path_print.append("\n{:>4} {:>14} {:>22} {:>37}".format(*path_run))
+            path_print.append(u"\n{:>4} {:>14} {:>22} {:>37}".format(*path_run))
 
         return "".join(path_print)
 

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -35,6 +35,8 @@ def contract_path(*operands, **kwargs):
         - 'optimal' An algorithm that tries all possible ways of
           contracting the listed tensors. Scales exponentially with
           the number of terms in the contraction.
+        - 'cheap' An approximate algorithm that is cheaper than 'greedy' for
+          very large contractions.
         - 'auto' Use the optimal approach for a small number of terms (currently
           4 or less), else use the greedy approach.
 
@@ -194,6 +196,8 @@ def contract_path(*operands, **kwargs):
         path = paths.optimal(input_sets, output_set, dimension_dict, memory_arg)
     elif path_type in ("greedy", "opportunistic", "auto"):
         path = paths.greedy(input_sets, output_set, dimension_dict, memory_arg)
+    elif path_type == 'cheap':
+        path = paths.cheap(input_sets, output_set, dimension_dict)
     else:
         raise KeyError("Path name %s not found" % path_type)
 
@@ -349,6 +353,8 @@ def contract(*operands, **kwargs):
         - 'optimal' An algorithm that tries all possible ways of
           contracting the listed tensors. Scales exponentially with
           the number of terms in the contraction.
+        - 'cheap' An approximate algorithm that is cheaper than 'greedy'
+          for very large contractions.
 
     memory_limit : int or None (default : None)
         The upper limit of the size of tensor created, by default, this will be

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -289,10 +289,10 @@ def ssa_to_linear(ssa_path):
         >>> ssa_to_linear([(0, 3), (1, 4), (2, 5)])
         [(0, 3), (1, 2), (0, 1)]
     """
-    ids = np.arange(sum(map(len, ssa_path)), dtype=np.int64)
+    ids = np.arange(1 + max(map(max, ssa_path)), dtype=np.int32)
     path = []
-    for i, ssa_ids in enumerate(ssa_path):
-        path.append(tuple(ids[ssa_id] for ssa_id in ssa_ids))
+    for ssa_ids in ssa_path:
+        path.append(tuple(int(ids[ssa_id]) for ssa_id in ssa_ids))
         for ssa_id in ssa_ids:
             ids[ssa_id:] -= 1
     return path
@@ -451,12 +451,11 @@ def _ssa_optimize(inputs, output, sizes):
 
 def eager(inputs, output, idx_dict):
     """
-    Finds the path by a quick-and-dirty method.
+    Finds the path by a three stage algorithm:
 
     1. Eagerly compute Hadamard products.
     2. Greedily compute contractions to maximize ``removed_size``
     3. Greedily compute outer products.
-    4. Finally call einsum with a single arg to fix output shape.
 
     This algorithm scales quadratically with respect to the
     maximum number of elements sharing a common dim.

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -349,7 +349,7 @@ def _update_ref_counts(dim_to_keys, dim_ref_counts, dims):
 
 def _ssa_optimize(inputs, output, sizes):
     """
-    This has an interface similar to :func:`optimize` but produces a path with
+    This has an interface similar to :func:`cheap` but produces a path with
     static single assignment ids rather than recycled linear ids.
     SSA ids are cheaper to work with and easier to reason about.
     """
@@ -438,21 +438,6 @@ def _ssa_optimize(inputs, output, sizes):
 
 
 def cheap(inputs, output, idx_dict):
-    """
-    Produces an optimization path similar to the greedy strategy
-    :func:`opt_einsum.paths.greedy`. This optimizer is cheaper and less
-    accurate than the default ``opt_einsum`` optimizer.
-
-    :param list inputs: A list of input shapes. These can be strings or sets or
-        frozensets of characters.
-    :param str output: An output shape. This can be a string or set or
-        frozenset of characters.
-    :param dict sizes: A mapping from dimensions (characters in inputs) to ints
-        that are the sizes of those dimensions.
-    :return: An optimization path: a list if tuples of contraction indices.
-    rtype: list
-    """
-
     """
     Finds the path by a quick-and-dirty method.
 

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -286,7 +286,7 @@ def ssa_to_linear(ssa_path):
     Convert a path with static single assignment ids to a path with recycled
     linear ids. For example::
 
-        >>> ssa_to_linear([(0, 3), (1, 4), (2, 5)])
+        >>> ssa_to_linear([(0, 3), (2, 4), (1, 5)])
         [(0, 3), (1, 2), (0, 1)]
     """
     ids = np.arange(1 + max(map(max, ssa_path)), dtype=np.int32)
@@ -304,7 +304,7 @@ def linear_to_ssa(path):
     assignment ids. For example::
 
         >>> linear_to_ssa([(0, 3), (1, 2), (0, 1)])
-        [(0, 3), (1, 4), (2, 5)]
+        [(0, 3), (2, 4), (1, 5)]
     """
     num_inputs = sum(map(len, path)) - len(path) + 1
     linear_to_ssa = list(range(num_inputs))

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -434,7 +434,7 @@ def _ssa_optimize(inputs, output, sizes):
             _push_candidate(output, sizes, remaining, footprints, dim_ref_counts, k1, k2s, queue)
 
     # Greedily compute pairwise outer products.
-    queue = [(helpers.compute_size_by_dict(key, sizes), ssa_id, key)
+    queue = [(helpers.compute_size_by_dict(key & output, sizes), ssa_id, key)
              for key, ssa_id in remaining.items()]
     heapq.heapify(queue)
     _, ssa_id1, k1 = heapq.heappop(queue)

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from . import helpers
 
-__all__ = ["optimal", "greedy", "cheap"]
+__all__ = ["optimal", "greedy", "eager"]
 
 
 def optimal(input_sets, output_set, idx_dict, memory_limit):
@@ -350,7 +350,7 @@ def _update_ref_counts(dim_to_keys, dim_ref_counts, dims):
 
 def _ssa_optimize(inputs, output, sizes):
     """
-    This has an interface similar to :func:`cheap` but produces a path with
+    This has an interface similar to :func:`eager` but produces a path with
     static single assignment ids rather than recycled linear ids.
     SSA ids are cheaper to work with and easier to reason about.
     """
@@ -439,7 +439,7 @@ def _ssa_optimize(inputs, output, sizes):
     return ssa_path
 
 
-def cheap(inputs, output, idx_dict):
+def eager(inputs, output, idx_dict):
     """
     Finds the path by a quick-and-dirty method.
 
@@ -472,7 +472,7 @@ def cheap(inputs, output, idx_dict):
     >>> isets = [set('abd'), set('ac'), set('bdc')]
     >>> oset = set('')
     >>> idx_sizes = {'a': 1, 'b':2, 'c':3, 'd':4}
-    >>> cheap(isets, oset, idx_sizes)
+    >>> eager(isets, oset, idx_sizes)
     [(0, 2), (0, 1)]
     """
     ssa_path = _ssa_optimize(inputs, output, idx_dict)

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -284,7 +284,10 @@ def greedy(input_sets, output_set, idx_dict, memory_limit):
 def ssa_to_linear(ssa_path):
     """
     Convert a path with static single assignment ids to a path with recycled
-    linear ids.
+    linear ids. For example::
+
+        >>> ssa_to_linear([(0, 3), (1, 4), (2, 5)])
+        [(0, 3), (1, 2), (0, 1)]
     """
     ids = np.arange(sum(map(len, ssa_path)), dtype=np.int64)
     path = []
@@ -298,7 +301,10 @@ def ssa_to_linear(ssa_path):
 def linear_to_ssa(path):
     """
     Convert a path with recycled linear ids to a path with static single
-    assignment ids.
+    assignment ids. For example::
+
+        >>> linear_to_ssa([(0, 3), (1, 2), (0, 1)])
+        [(0, 3), (1, 4), (2, 5)]
     """
     num_inputs = sum(map(len, path)) - len(path) + 1
     linear_to_ssa = list(range(num_inputs))

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -317,18 +317,16 @@ def _get_candidate(output, sizes, remaining, costs, dim_ref_counts, k1, k2):
     two = k1 & k2
     one = either - two
     k12 = (either & output) | (two & dim_ref_counts[3]) | (one & dim_ref_counts[2])
-    cost = costs[k1] + costs[k2] + 2 * helpers.compute_size_by_dict(k12, sizes)
+    cost = costs[k1] + costs[k2] + helpers.compute_size_by_dict(k12, sizes)
     id1 = remaining[k1]
     id2 = remaining[k2]
     if id1 > id2:
         k1, id1, k2, id2 = k2, id2, k1, id1
-    cost = cost, id1, id2  # break ties to ensure determinism
+    cost = cost, id2, id1  # break ties to ensure determinism
     return cost, k1, k2, k12
 
 
 def _push_candidate(output, sizes, remaining, costs, dim_ref_counts, k1, k2s, queue):
-    if not k2s:
-        return
     candidate = min(_get_candidate(output, sizes, remaining, costs, dim_ref_counts, k1, k2)
                     for k2 in k2s)
     heapq.heappush(queue, candidate)
@@ -390,13 +388,13 @@ def _ssa_optimize(inputs, output, sizes):
         for count in [2, 3]}
 
     # Compute separable part of the objective function for contractions.
-    costs = {key: -helpers.compute_size_by_dict(key, sizes) for key in remaining}
+    costs = {key: -0.5 * helpers.compute_size_by_dict(key, sizes) for key in remaining}
 
     # Find initial candidate contractions.
     queue = []
     for dim, keys in dim_to_keys.items():
         keys = sorted(keys, key=remaining.__getitem__)
-        for i, k1 in enumerate(keys):
+        for i, k1 in enumerate(keys[:-1]):
             k2s = keys[1 + i:]
             _push_candidate(output, sizes, remaining, costs, dim_ref_counts, k1, k2s, queue)
 
@@ -420,12 +418,14 @@ def _ssa_optimize(inputs, output, sizes):
                 dim_to_keys[dim].add(k12)
         remaining[k12] = next(ssa_ids)
         _update_ref_counts(dim_to_keys, dim_ref_counts, k1 | k2 - output)
-        costs[k12] = -helpers.compute_size_by_dict(k12, sizes)
+        costs[k12] = -0.5 * helpers.compute_size_by_dict(k12, sizes)
 
         # Find new candidate contractions.
         k1 = k12
-        k2s = set(k2 for dim in k1 for k2 in dim_to_keys[dim] if k2 != k1)
-        _push_candidate(output, sizes, remaining, costs, dim_ref_counts, k1, k2s, queue)
+        k2s = set(k2 for dim in k1 for k2 in dim_to_keys[dim])
+        k2s.discard(k1)
+        if k2s:
+            _push_candidate(output, sizes, remaining, costs, dim_ref_counts, k1, k2s, queue)
 
     # Greedily compute pairwise outer products.
     queue = [(helpers.compute_size_by_dict(key, sizes), ssa_id, key)

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -1,11 +1,18 @@
 """
 Contains the path technology behind opt_einsum in addition to several path helpers
 """
+from __future__ import absolute_import, division, print_function
+
+import heapq
 import itertools
+from collections import defaultdict
+
+import numpy as np
 
 from . import helpers
 
-__all__ = ["optimal", "greedy"] 
+__all__ = ["optimal", "greedy", "cheap"]
+
 
 def optimal(input_sets, output_set, idx_dict, memory_limit):
     """
@@ -272,3 +279,214 @@ def greedy(input_sets, output_set, idx_dict, memory_limit):
         path_cost += best[0][1]
 
     return path
+
+
+def ssa_to_linear(ssa_path):
+    """
+    Convert a path with static single assignment ids to a path with recycled
+    linear ids.
+    """
+    ids = np.arange(sum(map(len, ssa_path)), dtype=np.int64)
+    path = []
+    for i, ssa_ids in enumerate(ssa_path):
+        path.append(tuple(ids[ssa_id] for ssa_id in ssa_ids))
+        for ssa_id in ssa_ids:
+            ids[ssa_id:] -= 1
+    return path
+
+
+def linear_to_ssa(path):
+    """
+    Convert a path with recycled linear ids to a path with static single
+    assignment ids.
+    """
+    num_inputs = sum(map(len, path)) - len(path) + 1
+    linear_to_ssa = list(range(num_inputs))
+    new_ids = itertools.count(num_inputs)
+    ssa_path = []
+    for ids in path:
+        ssa_path.append(tuple(linear_to_ssa[id_] for id_ in ids))
+        for id_ in sorted(ids, reverse=True):
+            del linear_to_ssa[id_]
+        linear_to_ssa.append(next(new_ids))
+    return ssa_path
+
+
+def _get_candidate(output, sizes, remaining, footprints, dim_ref_counts, k1, k2):
+    either = k1 | k2
+    two = k1 & k2
+    one = either - two
+    k12 = (either & output) | (two & dim_ref_counts[3]) | (one & dim_ref_counts[2])
+    footprint12 = helpers.compute_size_by_dict(k12, sizes)
+    cost = footprint12 - footprints[k1] - footprints[k2]
+    id1 = remaining[k1]
+    id2 = remaining[k2]
+    cost = cost, min(id1, id2), max(id1, id2)  # break ties to ensure determinism
+    return cost, k1, k2, k12
+
+
+def _push_candidate(output, sizes, remaining, footprints, dim_ref_counts, k1, k2s, queue):
+    if not k2s:
+        return
+    candidate = min(_get_candidate(output, sizes, remaining, footprints, dim_ref_counts, k1, k2)
+                    for k2 in k2s)
+    heapq.heappush(queue, candidate)
+
+
+def _update_ref_counts(dim_to_keys, dim_ref_counts, dims):
+    for dim in dims:
+        count = len(dim_to_keys[dim])
+        if count <= 1:
+            dim_ref_counts[2].discard(dim)
+            dim_ref_counts[3].discard(dim)
+        elif count == 2:
+            dim_ref_counts[2].add(dim)
+            dim_ref_counts[3].discard(dim)
+        else:
+            dim_ref_counts[2].add(dim)
+            dim_ref_counts[3].add(dim)
+
+
+def _ssa_optimize(inputs, output, sizes):
+    """
+    This has an interface similar to :func:`optimize` but produces a path with
+    static single assignment ids rather than recycled linear ids.
+    SSA ids are cheaper to work with and easier to reason about.
+    """
+    # A dim common to all terms might as well be an output dim.
+    inputs = list(map(frozenset, inputs))
+    output = frozenset(output) | frozenset.intersection(*inputs)
+
+    # Deduplicate shapes by eagerly computing Hadamard products.
+    remaining = {}  # key -> ssa_id
+    ssa_ids = itertools.count(len(inputs))
+    ssa_path = []
+    for ssa_id, key in enumerate(inputs):
+        if key in remaining:
+            ssa_path.append((remaining[key], ssa_id))
+            remaining[key] = next(ssa_ids)
+        else:
+            remaining[key] = ssa_id
+
+    # Compute footprints of each tensor.
+    footprints = {key: helpers.compute_size_by_dict(key, sizes)
+                  for key in remaining}
+
+    # Keep track of possible contraction dims.
+    dim_to_keys = defaultdict(set)
+    for key in remaining:
+        for dim in key - output:
+            dim_to_keys[dim].add(key)
+
+    # Keep track of the number of tensors using each dim; when the dim is no longer
+    # used it can be contracted. Since we specialize to binary ops, we only care about
+    # ref counts of >=2 or >=3.
+    dim_ref_counts = {
+        count: set(dim for dim, keys in dim_to_keys.items() if len(keys) >= count) - output
+        for count in [2, 3]}
+
+    # Find initial candidate contractions.
+    queue = []
+    for dim, keys in dim_to_keys.items():
+        keys = list(keys)
+        for i, k1 in enumerate(keys):
+            k2s = keys[:i]
+            _push_candidate(output, sizes, remaining, footprints, dim_ref_counts, k1, k2s, queue)
+
+    # Greedily contract pairs of tensors.
+    while queue:
+        cost, k1, k2, k12 = heapq.heappop(queue)
+        if k1 not in remaining or k2 not in remaining:
+            continue  # candidate is obsolete
+
+        ssa_id1 = remaining.pop(k1)
+        ssa_id2 = remaining.pop(k2)
+        for dim in k1 - output:
+            dim_to_keys[dim].remove(k1)
+        for dim in k2 - output:
+            dim_to_keys[dim].remove(k2)
+        ssa_path.append((ssa_id2, ssa_id1))
+        if k12 in remaining:
+            ssa_path.append((remaining[k12], next(ssa_ids)))
+        else:
+            footprints[k12] = helpers.compute_size_by_dict(k12, sizes)
+            for dim in k12 - output:
+                dim_to_keys[dim].add(k12)
+        remaining[k12] = next(ssa_ids)
+        _update_ref_counts(dim_to_keys, dim_ref_counts, k1 | k2 - output)
+
+        # Find new candidate contractions.
+        k1 = k12
+        k2s = set(k2 for dim in k1 for k2 in dim_to_keys[dim] if k2 != k1)
+        _push_candidate(output, sizes, remaining, footprints, dim_ref_counts, k1, k2s, queue)
+
+    # Greedily compute pairwise outer products.
+    queue = [(len(key & output), ssa_id, key) for key, ssa_id in remaining.items()]
+    heapq.heapify(queue)
+    _, ssa_id1, k1 = heapq.heappop(queue)
+    while queue:
+        _, ssa_id2, k2 = heapq.heappop(queue)
+        ssa_path.append((ssa_id1, ssa_id2))
+        k12 = (k1 | k2) & output
+        cost = len(k12)
+        ssa_id12 = next(ssa_ids)
+        _, ssa_id1, k1 = heapq.heappushpop(queue, (cost, ssa_id12, k12))
+
+    # Perform one final reduction to match output shape.
+    ssa_path.append((ssa_id1,))
+    return ssa_path
+
+
+def cheap(inputs, output, idx_dict):
+    """
+    Produces an optimization path similar to the greedy strategy
+    :func:`opt_einsum.paths.greedy`. This optimizer is cheaper and less
+    accurate than the default ``opt_einsum`` optimizer.
+
+    :param list inputs: A list of input shapes. These can be strings or sets or
+        frozensets of characters.
+    :param str output: An output shape. This can be a string or set or
+        frozenset of characters.
+    :param dict sizes: A mapping from dimensions (characters in inputs) to ints
+        that are the sizes of those dimensions.
+    :return: An optimization path: a list if tuples of contraction indices.
+    rtype: list
+    """
+
+    """
+    Finds the path by a quick-and-dirty method.
+
+    1. Eagerly compute Hadamard products.
+    2. Greedily compute contractions to maximize ``removed_size``
+    3. Greedily compute outer products.
+    4. Finally call einsum with a single arg to fix output shape.
+
+    This algorithm scales quadratically with respect to the
+    maximum number of elements sharing a common dim.
+
+    Parameters
+    ----------
+    input_sets : list
+        List of sets that represent the lhs side of the einsum subscript
+    output_set : set
+        Set that represents the rhs side of the overall einsum subscript
+    idx_dict : dictionary
+        Dictionary of index sizes
+    memory_limit : int
+        The maximum number of elements in a temporary array
+
+    Returns
+    -------
+    path : list
+        The greedy contraction order within the memory limit constraint.
+
+    Examples
+    --------
+    >>> isets = [set('abd'), set('ac'), set('bdc')]
+    >>> oset = set('')
+    >>> idx_sizes = {'a': 1, 'b':2, 'c':3, 'd':4}
+    >>> greedy(isets, oset, idx_sizes, 5000)
+    [(0, 2), (0, 1)]
+    """
+    ssa_path = _ssa_optimize(inputs, output, idx_dict)
+    return ssa_to_linear(ssa_path)

--- a/opt_einsum/tests/test_contract.py
+++ b/opt_einsum/tests/test_contract.py
@@ -98,7 +98,7 @@ tests = [
 
 
 @pytest.mark.parametrize("string", tests)
-@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'cheap'])
+@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'eager'])
 def test_compare(optimize, string):
     views = helpers.build_views(string)
 
@@ -115,7 +115,7 @@ def test_drop_in_replacement(string):
 
 
 @pytest.mark.parametrize("string", tests)
-@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'cheap'])
+@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'eager'])
 def test_compare_greek(optimize, string):
     views = helpers.build_views(string)
 
@@ -129,7 +129,7 @@ def test_compare_greek(optimize, string):
 
 
 @pytest.mark.parametrize("string", tests)
-@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'cheap'])
+@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'eager'])
 def test_compare_blas(optimize, string):
     views = helpers.build_views(string)
 
@@ -139,7 +139,7 @@ def test_compare_blas(optimize, string):
 
 
 @pytest.mark.parametrize("string", tests)
-@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'cheap'])
+@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'eager'])
 def test_compare_blas_greek(optimize, string):
     views = helpers.build_views(string)
 
@@ -170,7 +170,7 @@ def test_printing():
 
 
 @pytest.mark.parametrize("string", tests)
-@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'cheap'])
+@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'eager'])
 @pytest.mark.parametrize("use_blas", [False, True])
 @pytest.mark.parametrize("out_spec", [False, True])
 def test_contract_expressions(string, optimize, use_blas, out_spec):

--- a/opt_einsum/tests/test_contract.py
+++ b/opt_einsum/tests/test_contract.py
@@ -99,14 +99,12 @@ tests = [
 
 
 @pytest.mark.parametrize("string", tests)
-def test_compare(string):
+@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'cheap'])
+def test_compare(optimize, string):
     views = helpers.build_views(string)
 
     ein = contract(string, *views, optimize=False, use_blas=False)
-    opt = contract(string, *views, optimize='greedy', use_blas=False)
-    assert np.allclose(ein, opt)
-
-    opt = contract(string, *views, optimize='optimal', use_blas=False)
+    opt = contract(string, *views, optimize=optimize, use_blas=False)
     assert np.allclose(ein, opt)
 
 
@@ -118,7 +116,8 @@ def test_drop_in_replacement(string):
 
 
 @pytest.mark.parametrize("string", tests)
-def test_compare_greek(string):
+@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'cheap'])
+def test_compare_greek(optimize, string):
     views = helpers.build_views(string)
 
     ein = contract(string, *views, optimize=False, use_blas=False)
@@ -126,27 +125,23 @@ def test_compare_greek(string):
     # convert to greek
     string = ''.join(compat.get_char(ord(c) + 848) if c not in ',->.' else c for c in string)
 
-    opt = contract(string, *views, optimize='greedy', use_blas=False)
-    assert np.allclose(ein, opt)
-
-    opt = contract(string, *views, optimize='optimal', use_blas=False)
+    opt = contract(string, *views, optimize=optimize, use_blas=False)
     assert np.allclose(ein, opt)
 
 
 @pytest.mark.parametrize("string", tests)
-def test_compare_blas(string):
+@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'cheap'])
+def test_compare_blas(optimize, string):
     views = helpers.build_views(string)
 
     ein = contract(string, *views, optimize=False)
-    opt = contract(string, *views, optimize='greedy')
-    assert np.allclose(ein, opt)
-
-    opt = contract(string, *views, optimize='optimal')
+    opt = contract(string, *views, optimize=optimize)
     assert np.allclose(ein, opt)
 
 
 @pytest.mark.parametrize("string", tests)
-def test_compare_blas_greek(string):
+@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'cheap'])
+def test_compare_blas_greek(optimize, string):
     views = helpers.build_views(string)
 
     ein = contract(string, *views, optimize=False)
@@ -154,10 +149,7 @@ def test_compare_blas_greek(string):
     # convert to greek
     string = ''.join(compat.get_char(ord(c) + 848) if c not in ',->.' else c for c in string)
 
-    opt = contract(string, *views, optimize='greedy')
-    assert np.allclose(ein, opt)
-
-    opt = contract(string, *views, optimize='optimal')
+    opt = contract(string, *views, optimize=optimize)
     assert np.allclose(ein, opt)
 
 
@@ -179,7 +171,7 @@ def test_printing():
 
 
 @pytest.mark.parametrize("string", tests)
-@pytest.mark.parametrize("optimize", ['greedy', 'optimal'])
+@pytest.mark.parametrize("optimize", ['greedy', 'optimal', 'cheap'])
 @pytest.mark.parametrize("use_blas", [False, True])
 @pytest.mark.parametrize("out_spec", [False, True])
 def test_contract_expressions(string, optimize, use_blas, out_spec):

--- a/opt_einsum/tests/test_contract.py
+++ b/opt_einsum/tests/test_contract.py
@@ -2,12 +2,11 @@
 Tets a series of opt_einsum contraction paths to ensure the results are the same for different paths
 """
 
-import sys
-
 import numpy as np
 import pytest
 
 from opt_einsum import compat, contract, contract_path, helpers, contract_expression
+from opt_einsum.paths import linear_to_ssa, ssa_to_linear
 
 tests = [
     # Test hadamard-like products
@@ -223,3 +222,12 @@ def test_contract_expression_with_constants(string, constants):
     print(expr)
     out = expr(*ctrc_args)
     assert np.allclose(expected, out)
+
+
+@pytest.mark.parametrize('equation', tests)
+def test_linear_vs_ssa(equation):
+    views = helpers.build_views(equation)
+    linear_path, _ = contract_path(equation, *views)
+    ssa_path = linear_to_ssa(linear_path)
+    linear_path2 = ssa_to_linear(ssa_path)
+    assert linear_path2 == linear_path

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -26,10 +26,14 @@ explicit_path_tests = {
 }
 
 path_edge_tests = [
-    ['eb,cb,fb->cef', ((0, 2), (0, 1))],
-    ['dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
-    ['bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
-    ['dcc,fce,ea,dbf->ab', ((1, 2), (0, 1), (0, 1))],
+    ['greedy', 'eb,cb,fb->cef', ((0, 2), (0, 1))],
+    ['optimal', 'eb,cb,fb->cef', ((0, 2), (0, 1))],
+    ['greedy', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
+    ['optimal', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
+    ['greedy', 'bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
+    ['optimal', 'bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
+    ['greedy', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 1), (0, 1))],
+    ['optimal', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 2), (0, 1))],
 ]
 
 
@@ -134,8 +138,7 @@ def test_memory_paths():
     assert check_path(path_ret[0], [(0, 3), (0, 4), (0, 2), (0, 2), (0, 1)])
 
 
-@pytest.mark.parametrize("alg", ['greedy', 'optimal'])
-@pytest.mark.parametrize("expression,order", path_edge_tests)
+@pytest.mark.parametrize("alg,expression,order", path_edge_tests)
 def test_path_edge_cases(alg, expression, order):
     views = oe.helpers.build_views(expression)
 

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -26,12 +26,16 @@ explicit_path_tests = {
 }
 
 path_edge_tests = [
+    ['cheap', 'eb,cb,fb->cef', ((0, 2), (0, 1))],
     ['greedy', 'eb,cb,fb->cef', ((0, 2), (0, 1))],
     ['optimal', 'eb,cb,fb->cef', ((0, 2), (0, 1))],
+    ['cheap', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
     ['greedy', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
     ['optimal', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
+    ['cheap', 'bca,cdb,dbf,afc->', ((0, 3), (0, 1), (0, 1))],
     ['greedy', 'bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
     ['optimal', 'bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
+    ['cheap', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 2), (0, 1))],
     ['greedy', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 1), (0, 1))],
     ['optimal', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 2), (0, 1))],
 ]
@@ -172,10 +176,12 @@ def test_greedy_edge_cases():
     assert check_path(path, [(0, 1), (0, 2), (0, 1)])
 
 
-def test_can_optimize_outer_products():
+@pytest.mark.parametrize("optimize", ['greedy', 'cheap'])
+def test_can_optimize_outer_products(optimize):
     a, b, c = [np.random.randn(10, 10) for _ in range(3)]
     d = np.random.randn(10, 2)
-    assert oe.contract_path("ab,cd,ef,fg", a, b, c, d, path='greedy')[0] == [(2, 3), (0, 2), (0, 1)]
+    actual = oe.contract_path("ab,cd,ef,fg", a, b, c, d, path=optimize)[0]
+    assert actual in [[(2, 3), (0, 2), (0, 1)], [(2, 3), (0, 2), (0, 1)]]
 
 
 @pytest.mark.parametrize('num_symbols', [2, 3, 26, 26 + 26, 256 - 140, 300])

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -32,10 +32,10 @@ path_edge_tests = [
     ['eager', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
     ['greedy', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
     ['optimal', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
-    ['eager', 'bca,cdb,dbf,afc->', ((0, 3), (0, 1), (0, 1))],
+    ['eager', 'bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
     ['greedy', 'bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
     ['optimal', 'bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
-    ['eager', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 2), (0, 1))],
+    ['eager', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 1), (0, 1))],
     ['greedy', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 1), (0, 1))],
     ['optimal', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 2), (0, 1))],
 ]

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -26,14 +26,10 @@ explicit_path_tests = {
 }
 
 path_edge_tests = [
-    ['greedy', 'eb,cb,fb->cef', ((0, 2), (0, 1))],
-    ['optimal', 'eb,cb,fb->cef', ((0, 2), (0, 1))],
-    ['greedy', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
-    ['optimal', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
-    ['greedy', 'bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
-    ['optimal', 'bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
-    ['greedy', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 1), (0, 1))],
-    ['optimal', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 2), (0, 1))],
+    ['eb,cb,fb->cef', ((0, 2), (0, 1))],
+    ['dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
+    ['bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
+    ['dcc,fce,ea,dbf->ab', ((1, 2), (0, 1), (0, 1))],
 ]
 
 
@@ -138,7 +134,8 @@ def test_memory_paths():
     assert check_path(path_ret[0], [(0, 3), (0, 4), (0, 2), (0, 2), (0, 1)])
 
 
-@pytest.mark.parametrize("alg,expression,order", path_edge_tests)
+@pytest.mark.parametrize("alg", ['greedy', 'optimal', 'cheap'])
+@pytest.mark.parametrize("expression,order", path_edge_tests)
 def test_path_edge_cases(alg, expression, order):
     views = oe.helpers.build_views(expression)
 

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -181,7 +181,7 @@ def test_can_optimize_outer_products(optimize):
     a, b, c = [np.random.randn(10, 10) for _ in range(3)]
     d = np.random.randn(10, 2)
     actual = oe.contract_path("ab,cd,ef,fg", a, b, c, d, path=optimize)[0]
-    assert actual in [[(2, 3), (0, 2), (0, 1)], [(2, 3), (0, 2), (0, 1)]]
+    assert actual == [(2, 3), (0, 2), (0, 1)]
 
 
 @pytest.mark.parametrize('num_symbols', [2, 3, 26, 26 + 26, 256 - 140, 300])

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -134,7 +134,7 @@ def test_memory_paths():
     assert check_path(path_ret[0], [(0, 3), (0, 4), (0, 2), (0, 2), (0, 1)])
 
 
-@pytest.mark.parametrize("alg", ['greedy', 'optimal', 'cheap'])
+@pytest.mark.parametrize("alg", ['greedy', 'optimal'])
 @pytest.mark.parametrize("expression,order", path_edge_tests)
 def test_path_edge_cases(alg, expression, order):
     views = oe.helpers.build_views(expression)

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -26,16 +26,16 @@ explicit_path_tests = {
 }
 
 path_edge_tests = [
-    ['cheap', 'eb,cb,fb->cef', ((0, 2), (0, 1))],
+    ['eager', 'eb,cb,fb->cef', ((0, 2), (0, 1))],
     ['greedy', 'eb,cb,fb->cef', ((0, 2), (0, 1))],
     ['optimal', 'eb,cb,fb->cef', ((0, 2), (0, 1))],
-    ['cheap', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
+    ['eager', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
     ['greedy', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
     ['optimal', 'dd,fb,be,cdb->cef', ((0, 3), (0, 1), (0, 1))],
-    ['cheap', 'bca,cdb,dbf,afc->', ((0, 3), (0, 1), (0, 1))],
+    ['eager', 'bca,cdb,dbf,afc->', ((0, 3), (0, 1), (0, 1))],
     ['greedy', 'bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
     ['optimal', 'bca,cdb,dbf,afc->', ((1, 2), (0, 2), (0, 1))],
-    ['cheap', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 2), (0, 1))],
+    ['eager', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 2), (0, 1))],
     ['greedy', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 1), (0, 1))],
     ['optimal', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 2), (0, 1))],
 ]
@@ -176,7 +176,7 @@ def test_greedy_edge_cases():
     assert check_path(path, [(0, 1), (0, 2), (0, 1)])
 
 
-@pytest.mark.parametrize("optimize", ['greedy', 'cheap'])
+@pytest.mark.parametrize("optimize", ['greedy', 'eager'])
 def test_can_optimize_outer_products(optimize):
     a, b, c = [np.random.randn(10, 10) for _ in range(3)]
     d = np.random.randn(10, 2)


### PR DESCRIPTION
Addresses #56 
Mirrors ~~https://github.com/uber/pyro/pull/1424~~ https://github.com/uber/pyro/pull/1430

## Description

Implements a cheap approximate optimizer for very large paths. This is currently over 100x faster on some large contractions in Pyro, but produces slightly suboptimal paths.

## Todos
- [x] Fix issues with determinism, required by `shared_intermediates`
- [x] Ensure algorithm is not much worse than `greedy`
- ~~Add quality tests (will be easier after #61)~~

## Questions
- [x] How should we be computing the final outer products? Can we do this all in one go?
- [x] What tests should I add?

## Status
- [x] Ready to go