### PR TITLE
Support more symbols for subscripts (#67)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -147,5 +147,6 @@ Table of Contents
    :maxdepth: 1
    :caption: Help & Reference:
 
+   input_format
    api
    changelog

--- a/docs/source/input_format.rst
+++ b/docs/source/input_format.rst
@@ -1,0 +1,41 @@
+============
+Input Format
+============
+
+The ``opt_einsum`` package is a drop-in replacement for the ``np.einsum`` function
+and supports all input formats that ``np.einsum`` supports.
+
+TBA: "Normal" inputs
+
+In ``opt_einsum``, you can also put anything hashable and comparable such as `str` in the subscript list.
+Note ``np.einsum`` currently does not support this syntax. A simple example of the syntax is:
+
+.. code:: python
+
+    >>> x, y, z = np.ones((1, 2)), np.ones((2, 2)), np.ones((2, 1))
+    >>> oe.contract(x, ('left', 'bond1'), y, ('bond1', 'bond2'), z, ('bond2', 'right'), ('left', 'right'))
+    array([[4.]])
+
+The subscripts need to be hashable so that ``opt_einsum`` can efficiently process them, and
+they should also be comparable because in this way we can keep a consistent behavior between integer 
+subscripts and other types of subscripts. For example:
+
+.. code:: python
+
+    >>> x = np.array([[0, 1], [2, 0]])
+    >>> oe.contract(x, (0, 1))  # original matrix
+    array([[0, 1],
+           [2, 0]])
+    >>> oe.contract(x, (1, 0)) # the transpose
+    array([[0, 2],
+           [1, 0]])
+    >>> oe.contract(x, ('a', 'b'))  # original matrix, consistent behavior
+    array([[0, 1],
+           [2, 0]])
+    >>> oe.contract(x, ('b', 'a')) # the transpose, consistent behavior
+    array([[0, 2],
+           [1, 0]])
+    >>> oe.contract(x, (0, 'a')) # relative sequence undefined, can't determine output
+    TypeError: For this input type lists must contain either Ellipsis or hashable and comparable object (e.g. int, str)
+
+

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -235,7 +235,6 @@ def parse_einsum_input(operands):
     >>> parse_einsum_input((a, [Ellipsis, 0], b, [Ellipsis, 0]))
     ('za,xza', 'xz', [a, b])
     """
-    #import ipdb; ipdb.set_trace()
 
     if len(operands) == 0:
         raise ValueError("No input operands")

--- a/opt_einsum/tests/test_input.py
+++ b/opt_einsum/tests/test_input.py
@@ -73,11 +73,12 @@ def test_type_errors():
     string = '...a->...a'
     views = build_views(string)
 
+    # Subscript list must contain Ellipsis or hashable object
     with pytest.raises(TypeError):
-        contract(views[0], [Ellipsis, 'a'], [Ellipsis, 0])
+        contract(views[0], [Ellipsis, 0], [Ellipsis, ['a']])
 
     with pytest.raises(TypeError):
-        contract(views[0], [Ellipsis, 0], [Ellipsis, 'a'])
+        contract(views[0], [Ellipsis, dict()], [Ellipsis, 'a'])
 
 
 def test_value_errors():
@@ -236,3 +237,12 @@ def test_large_int_input_format():
     string_output = contract(string, x, y, z)
     int_output = contract(x, (1000, 1001), y, (1001, 1002), z, (1002, 1003))
     assert np.allclose(string_output, int_output)
+
+
+def test_hashable_object_input_format():
+    string = 'ab,bc,cd'
+    x, y, z = build_views(string)
+    string_output = contract(string, x, y, z)
+    hash_output = contract(x, ('left', 'bond1'), y, ('bond1', 'bond2'), z, ('bond2', 'right'))
+    assert np.allclose(string_output, hash_output)
+

--- a/opt_einsum/tests/test_input.py
+++ b/opt_einsum/tests/test_input.py
@@ -246,8 +246,10 @@ def test_hashable_object_input_format():
     string = 'ab,bc,cd'
     x, y, z = build_views(string)
     string_output = contract(string, x, y, z)
-    hash_output = contract(x, ('left', 'bond1'), y, ('bond1', 'bond2'), z, ('bond2', 'right'))
-    assert np.allclose(string_output, hash_output)
+    hash_output1 = contract(x, ('left', 'bond1'), y, ('bond1', 'bond2'), z, ('bond2', 'right'))
+    hash_output2 = contract(x, ('left', 'bond1'), y, ('bond1', 'bond2'), z, ('bond2', 'right'), ('left', 'right'))
+    assert np.allclose(string_output, hash_output1)
+    assert np.allclose(hash_output1, hash_output2)
     for i in range(1, 10):
         transpose_output = contract(x, ('b' * i, 'a' * i))
         assert np.allclose(transpose_output, x.T)

--- a/opt_einsum/tests/test_input.py
+++ b/opt_einsum/tests/test_input.py
@@ -73,7 +73,7 @@ def test_type_errors():
     string = '...a->...a'
     views = build_views(string)
 
-    # Subscript list must contain Ellipsis or hashable object
+    # Subscript list must contain Ellipsis or (hashable && comparable) object
     with pytest.raises(TypeError):
         contract(views[0], [Ellipsis, 0], [Ellipsis, ['a']])
 
@@ -237,6 +237,9 @@ def test_large_int_input_format():
     string_output = contract(string, x, y, z)
     int_output = contract(x, (1000, 1001), y, (1001, 1002), z, (1002, 1003))
     assert np.allclose(string_output, int_output)
+    for i in range(10):
+        transpose_output = contract(x, (i+1, i))
+        assert np.allclose(transpose_output, x.T)
 
 
 def test_hashable_object_input_format():
@@ -245,4 +248,6 @@ def test_hashable_object_input_format():
     string_output = contract(string, x, y, z)
     hash_output = contract(x, ('left', 'bond1'), y, ('bond1', 'bond2'), z, ('bond2', 'right'))
     assert np.allclose(string_output, hash_output)
-
+    for i in range(1, 10):
+        transpose_output = contract(x, ('b' * i, 'a' * i))
+        assert np.allclose(transpose_output, x.T)


### PR DESCRIPTION
* Add more symbol support based on hash

* Refactor the converting to subscripts routine a little bit

* Update tests

## Description
Make opt_einsum support anything hashable as subscripts, such as:
```python
contract(arr1, ['left edge', 'bond'], arr2, ['bond', 'right edge'])
```
See #67 

## Questions
- [x] I've tried to add the new feature to the document, but it seems the document does not have a chapter describing the inputs. Maybe I've left out something or maybe this should be solved in a different PR?

## Status
- [x] Ready to go