### PR TITLE
input fixes and docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -123,6 +123,7 @@ Table of Contents
    :caption: Getting Started
 
    install
+   input_format
    backends
    reusing_paths
    sharing_intermediates
@@ -147,6 +148,5 @@ Table of Contents
    :maxdepth: 1
    :caption: Help & Reference:
 
-   input_format
    api
    changelog

--- a/docs/source/input_format.rst
+++ b/docs/source/input_format.rst
@@ -24,8 +24,8 @@ followed by the array arguments:
     >>> z.shape
     (5, 2)
 
-The main difference is that thousands of symbols in the form of unicode
-characters can be used:
+However, in addition to the standard alphabet, ``opt_einsum`` also supports
+unicode characters:
 
 .. code:: python
 
@@ -33,7 +33,8 @@ characters can be used:
     >>> oe.contract(eq, x, y).shape
     (5, 2)
 
-One way to access these programmatically is through the function
+This enables access to thousands of possible index labels. One way to access
+these programmatically is through the function
 :func:`~opt_einsum.parser.get_symbol`:
 
     >>> oe.get_symbol(805)

--- a/docs/source/input_format.rst
+++ b/docs/source/input_format.rst
@@ -2,13 +2,71 @@
 Input Format
 ============
 
-The ``opt_einsum`` package is a drop-in replacement for the ``np.einsum`` function
-and supports all input formats that ``np.einsum`` supports.
+The ``opt_einsum`` package is a drop-in replacement for the ``np.einsum``
+function and supports all input formats that ``np.einsum`` supports. There are
+two styles of input accepted, a basic introduction to which can be found in the
+documentation for :func:`numpy.einsum`. In addition to this, ``opt_einsum``
+extends the allowed index labels to unicode or arbitrary hashable, comparable
+objects in order to handle large contractions with many indices.
 
-TBA: "Normal" inputs
 
-In ``opt_einsum``, you can also put anything hashable and comparable such as `str` in the subscript list.
-Note ``np.einsum`` currently does not support this syntax. A simple example of the syntax is:
+'Equation' Input
+----------------
+
+As with :func:`numpy.einsum`, here you specify an equation as a string,
+followed by the array arguments:
+
+.. code:: python
+
+    >>> eq = 'ijk,jkl->li'
+    >>> x, y = np.random.rand(2, 3, 4), np.random.rand(3, 4, 5)
+    >>> z = oe.contract(eq, x, y)
+    >>> z.shape
+    (5, 2)
+
+The main difference is that thousands of symbols in the form of unicode
+characters can be used:
+
+.. code:: python
+
+    >>> eq = "αβγ,βγδ->δα"
+    >>> oe.contract(eq, x, y).shape
+    (5, 2)
+
+One way to access these programmatically is through the function
+:func:`~opt_einsum.parser.get_symbol`:
+
+    >>> oe.get_symbol(805)
+    'α'
+
+which maps an ``int`` to a unicode characater. Note that as with
+:func:`numpy.einsum` if the output is not specified with ``->`` it will default
+to the sorted order of all indices appearing once:
+
+.. code:: python
+
+    >>> eq = "αβγ,βγδ"  # "->αδ" is implicit
+    >>> oe.contract(eq, x, y).shape
+    (2, 5)
+
+
+'Interleaved' Input
+-------------------
+
+The other input format is to 'interleave' the array arguments with their index
+labels ('subscripts') in pairs, optionally specifying the output indices as a
+final argument. As with :func:`numpy.einsum`, integers are allowed as these
+index labels:
+
+.. code:: python
+
+    >>> oe.contract(x, [1, 2, 3], y, [2, 3, 4], [4, 1]).shape
+    >>> (5, 2)
+
+with the default output order again specified by the sorted order of indices
+appearing once. However, unlike :func:`numpy.einsum`, in ``opt_einsum`` you can
+also put *anything* hashable and comparable such as `str` in the subscript list.
+A simple example of this syntax is:
 
 .. code:: python
 
@@ -17,8 +75,7 @@ Note ``np.einsum`` currently does not support this syntax. A simple example of t
     array([[4.]])
 
 The subscripts need to be hashable so that ``opt_einsum`` can efficiently process them, and
-they should also be comparable because in this way we can keep a consistent behavior between integer 
-subscripts and other types of subscripts. For example:
+they should also be comparable so as to allow a default sorted output. For example:
 
 .. code:: python
 

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -806,7 +806,7 @@ def contract_expression(subscripts, *shapes, **kwargs):
                              "`ContractExpression`, not when building it.".format(arg))
 
     if not isinstance(subscripts, compat.strings):
-        subscripts, shapes = parser.convert_interleaved_input((subscripts, *shapes))
+        subscripts, shapes = parser.convert_interleaved_input((subscripts,) + shapes)
 
     kwargs['_gen_expression'] = True
 

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -805,6 +805,9 @@ def contract_expression(subscripts, *shapes, **kwargs):
             raise ValueError("'{}' should only be specified when calling a "
                              "`ContractExpression`, not when building it.".format(arg))
 
+    if not isinstance(subscripts, compat.strings):
+        subscripts, shapes = parser.convert_interleaved_input((subscripts, *shapes))
+
     kwargs['_gen_expression'] = True
 
     # build dict of constant indices mapped to arrays

--- a/opt_einsum/tests/test_contract.py
+++ b/opt_einsum/tests/test_contract.py
@@ -194,6 +194,15 @@ def test_contract_expressions(string, optimize, use_blas, out_spec):
     assert string in expr.__str__()
 
 
+def test_contract_expression_interleaved_input():
+    x, y, z = (np.random.randn(2, 2) for _ in 'xyz')
+    expected = np.einsum(x, [0, 1], y, [1, 2], z, [2, 3], [3, 0])
+    xshp, yshp, zshp = ((2, 2) for _ in 'xyz')
+    expr = contract_expression(xshp, [0, 1], yshp, [1, 2], zshp, [2, 3], [3, 0])
+    out = expr(x, y, z)
+    assert np.allclose(out, expected)
+
+
 @pytest.mark.parametrize("string,constants", [
     ('hbc,bdef,cdkj,ji,ikeh,lfo', [1, 2, 3, 4]),
     ('bdef,cdkj,ji,ikeh,hbc,lfo', [0, 1, 2, 3]),


### PR DESCRIPTION
## Description
Makes ``contract_expression`` accept interleaved-style input (fixes #71) and adds general documentation on the input formats (resolves #70) following on from #67.

## Questions
- [ ] I've moved the input section into the main doc sections as this seemed quite natural?

## Status
- [x] Ready to go