### PR TITLE
Allow overriding of transpose function

### DIFF
--- a/opt_einsum/backends/dispatch.py
+++ b/opt_einsum/backends/dispatch.py
@@ -23,13 +23,15 @@ _aliases = {
 }
 
 
-def _import_func(func, backend):
-    """Try and import ``{backend}.{func}``, raise an error if library is
-    installed but can't find that particular function.
+def _import_func(func, backend, default=None):
+    """Try and import ``{backend}.{func}``.
+    If library is installed and func is found, return the func;
+    otherwise if default is provided, return default;
+    otherwise raise an error.
     """
     try:
         lib = importlib.import_module(_aliases.get(backend, backend))
-        return getattr(lib, func)
+        return getattr(lib, func) if default is None else getattr(lib, func, default)
     except AttributeError:
         raise AttributeError("{} doesn't seem to provide the function {}".format(backend, func))
 
@@ -43,13 +45,14 @@ _cached_funcs = {
 }
 
 
-def get_func(func, backend='numpy'):
-    """Return ``{backend}.{func}``, e.g. ``numpy.einsum``, cache result.
+def get_func(func, backend='numpy', default=None):
+    """Return ``{backend}.{func}``, e.g. ``numpy.einsum``,
+    or a default func if provided. Cache result.
     """
     try:
         return _cached_funcs[func, backend]
     except KeyError:
-        fn = _import_func(func, backend)
+        fn = _import_func(func, backend, default)
         _cached_funcs[func, backend] = fn
         return fn
 

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -339,16 +339,17 @@ def _einsum(*operands, **kwargs):
     return fn(einsum_str, *operands, **kwargs)
 
 
+def _default_transpose(x, axes):
+    #  most libraries implement a method version
+    return x.transpose(axes)
+
+
 @sharing.transpose_cache_wrap
 def _transpose(x, axes, backend='numpy'):
     """Base transpose.
     """
-    try:
-        return x.transpose(axes)
-    except (AttributeError, TypeError):
-        # some libraries don't implement method version
-        fn = backends.get_func('transpose', backend)
-        return fn(x, axes)
+    fn = backends.get_func('transpose', backend, _default_transpose)
+    return fn(x, axes)
 
 
 @sharing.tensordot_cache_wrap


### PR DESCRIPTION
## Description

This PR makes backends fully overridable by checking each backed for a transpose function before using the default `.transpose()` method.

Before this PR, `_transpose()` would first look for a default implementation (`x.transpose(axes)`), and only if this failed look for an overridden backend `transpose()` function. This approach has two flaws: (1) backends cannot override the transpose function if a different `.transpose()` method already exists (e.g. in Pyro we want to track some metadata in `transpose()`); (2) the try-except may not play well with jit compilers like the PyTorch jit.

The only change in behavior is to the torch backend: before this PR `torch.transpose()` was used for transposes of 2 axes and `torch.permute()` was used for 3 or more axes; after this PR `torch.permute()` is always used.

## Status
- [x] Ready to go