### PR TITLE
Support use under PyTorch jit

### DIFF
--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -230,7 +230,7 @@ def contract_path(*operands, **kwargs):
             raise ValueError("Einstein sum subscript '{}' does not contain the "
                              "correct number of indices for operand {}.".format(input_subscripts[tnum], tnum))
         for cnum, char in enumerate(term):
-            dim = sh[cnum]
+            dim = int(sh[cnum])
 
             if char in dimension_dict:
                 # For broadcasting cases we always want the largest dim size


### PR DESCRIPTION
## Description

This fixes path optimizers to work when run under the PyTorch jit. The problem was that when running under the jit, `x.shape` is a tensor, and `x.shape[pos]` is also a tensor. These tensors can't be operated on as easily as ints. this PR merely casts to an `int`. Note this will still raise a warning in the PyTorch jit, but it is easy to filter out the warning; typically we want to optimize the path once, then replay compiled code multiple times assume tensor shapes are roughly similar.

## Tested

- ran locally, showing that this fixes some jit usage in Pyro

## Status
- [x] Ready to go