### PR TITLE
Implement backend='auto' and make it the default

### DIFF
--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -38,10 +38,11 @@ General backend for any ndarray
 
 This 'duck-typing' support just requires specifying the correct ``backend``
 argument for the type of arrays supplied when calling
-:func:`~opt_einsum.contract`. For example, if you had a library installed
+:func:`~opt_einsum.contract` or letting it be automatically discovered based on
+the first array (the default). For example, if you had a library installed
 called ``'foo'`` which provided an :class:`~numpy.ndarray` like object with a
 ``.shape`` attribute as well as ``foo.tensordot`` and ``foo.transpose`` then
-you could contract then with something like:
+you could contract them with something like:
 
 .. code-block:: python
 
@@ -49,7 +50,9 @@ you could contract then with something like:
 
 Behind the scenes :mod:`opt_einsum` will find the contraction path, perform
 pairwise contractions using e.g. ``foo.tensordot`` and finally return whatever
-type those functions return.
+type those functions return. In fact, if you don't want to be explicit you can
+leave ``backend='auto'`` here and ``opt_einsum`` will infer ``'foo'`` by
+itself.
 
 
 Dask
@@ -70,7 +73,7 @@ these requirements. For example:
      dask.array<da.random.normal, shape=(300, 4), dtype=float64, chunksize=(100, 4)>]
 
 
-    >>> dy = oe.contract("ab,bc,cd", *dxs, backend='dask')
+    >>> dy = oe.contract("ab,bc,cd", *dxs)  # will infer backend='dask'
     >>> dy
     dask.array<transpose, shape=(3, 4), dtype=float64, chunksize=(3, 4)>
 
@@ -101,7 +104,7 @@ supported. An example:
      <COO: shape=(200, 300), dtype=float64, nnz=600, sorted=False, duplicates=True>,
      <COO: shape=(300, 4), dtype=float64, nnz=12, sorted=False, duplicates=True>]
 
-    >>> sy = oe.contract("ab,bc,cd", *sxs, backend='sparse')
+    >>> sy = oe.contract("ab,bc,cd", *sxs)
     <COO: shape=(3, 4), dtype=float64, nnz=0, sorted=False, duplicates=False>
 
 

--- a/opt_einsum/backends/__init__.py
+++ b/opt_einsum/backends/__init__.py
@@ -4,7 +4,7 @@ Compute backends for opt_einsum.
 
 # Backends
 from .cupy import to_cupy
-from .dispatch import (get_func, has_einsum, build_expression, evaluate_constants, has_backend)
+from .dispatch import (get_func, has_einsum, has_tensordot, build_expression, evaluate_constants, has_backend)
 from .tensorflow import to_tensorflow
 from .theano import to_theano
 from .torch import to_torch
@@ -12,8 +12,10 @@ from .torch import to_torch
 __all__ = [
     'get_func',
     'has_einsum',
+    'has_tensordot',
     'build_expression',
     'evaluate_constants',
+    'has_backend',
     'to_tensorflow',
     'to_theano',
     'to_cupy',

--- a/opt_einsum/backends/dispatch.py
+++ b/opt_einsum/backends/dispatch.py
@@ -13,7 +13,7 @@ from . import tensorflow as _tensorflow
 from . import theano as _theano
 from . import torch as _torch
 
-__all__ = ["get_func", "has_einsum", "build_expression", "evaluate_constants", "has_backend"]
+__all__ = ["get_func", "has_einsum", "has_tensordot", "build_expression", "evaluate_constants", "has_backend"]
 
 # known non top-level imports
 _aliases = {
@@ -74,6 +74,24 @@ def has_einsum(backend):
             _has_einsum[backend] = False
 
         return _has_einsum[backend]
+
+
+_has_tensordot = {}
+
+
+def has_tensordot(backend):
+    """Check if ``{backend}.tensordot`` exists, cache result for performance.
+    """
+    try:
+        return _has_tensordot[backend]
+    except KeyError:
+        try:
+            get_func('tensordot', backend)
+            _has_tensordot[backend] = True
+        except AttributeError:
+            _has_tensordot[backend] = False
+
+        return _has_tensordot[backend]
 
 
 # Dispatch to correct expression backend

--- a/opt_einsum/backends/tensorflow.py
+++ b/opt_einsum/backends/tensorflow.py
@@ -21,9 +21,12 @@ def _get_tensorflow_and_device():
         import tensorflow as tf
 
         try:
-            eager = tf.contrib.eager.in_eager_mode()
+            eager = tf.executing_eagerly()
         except AttributeError:
-            eager = False
+            try:
+                eager = tf.contrib.eager.in_eager_mode()
+            except AttributeError:
+                eager = False
 
         device = tf.test.gpu_device_name()
         if not device:

--- a/opt_einsum/tests/test_backends.py
+++ b/opt_einsum/tests/test_backends.py
@@ -64,7 +64,7 @@ def test_tensorflow(string):
 
     # test non-conversion mode
     tensorflow_views = [backends.to_tensorflow(view) for view in views]
-    expr(*tensorflow_views, backend='tensorflow')
+    expr(*tensorflow_views)
 
 
 @pytest.mark.skipif(not found_tensorflow, reason="Tensorflow not installed.")
@@ -92,7 +92,7 @@ def test_tensorflow_with_constants():
     assert np.allclose(res_exp, res_got2)
 
     # check tensorflow call returns tensorflow still
-    res_got3 = expr(backends.to_tensorflow(var), backend='tensorflow')
+    res_got3 = expr(backends.to_tensorflow(var))
     assert isinstance(res_got3, tf.Tensor)
 
 
@@ -135,7 +135,7 @@ def test_theano(string):
 
     # test non-conversion mode
     theano_views = [backends.to_theano(view) for view in views]
-    theano_opt = expr(*theano_views, backend='theano')
+    theano_opt = expr(*theano_views)
     assert isinstance(theano_opt, theano.tensor.TensorVariable)
 
 
@@ -161,7 +161,7 @@ def test_theano_with_constants():
     assert np.allclose(res_exp, res_got2)
 
     # check theano call returns theano still
-    res_got3 = expr(backends.to_theano(var), backend='theano')
+    res_got3 = expr(backends.to_theano(var))
     assert isinstance(res_got3, theano.tensor.TensorVariable)
 
 
@@ -202,7 +202,7 @@ def test_cupy(string):  # pragma: no cover
 
     # test non-conversion mode
     cupy_views = [backends.to_cupy(view) for view in views]
-    cupy_opt = expr(*cupy_views, backend='cupy')
+    cupy_opt = expr(*cupy_views)
     assert isinstance(cupy_opt, cupy.ndarray)
     assert np.allclose(ein, cupy.asnumpy(cupy_opt))
 
@@ -230,7 +230,7 @@ def test_cupy_with_constants():  # pragma: no cover
     assert np.allclose(res_exp, res_got2)
 
     # check cupy call returns cupy still
-    res_got3 = expr(cupy.asarray(var), backend='cupy')
+    res_got3 = expr(cupy.asarray(var))
     assert isinstance(res_got3, cupy.ndarray)
     assert np.allclose(res_exp, res_got3.get())
 
@@ -246,7 +246,7 @@ def test_dask(string):
 
     # test non-conversion mode
     da_views = [da.from_array(x, chunks=(2)) for x in views]
-    da_opt = expr(*da_views, backend='dask')
+    da_opt = expr(*da_views)
 
     # check type is maintained when not using numpy arrays
     assert isinstance(da_opt, da.Array)
@@ -254,7 +254,7 @@ def test_dask(string):
     assert np.allclose(ein, np.array(da_opt))
 
     # try raw contract
-    da_opt = contract(string, *da_views, backend='dask')
+    da_opt = contract(string, *da_views)
     assert isinstance(da_opt, da.Array)
     assert np.allclose(ein, np.array(da_opt))
 
@@ -277,7 +277,7 @@ def test_sparse(string):
 
     # test non-conversion mode
     sparse_views = [sparse.COO.from_numpy(x) for x in views]
-    sparse_opt = expr(*sparse_views, backend='sparse')
+    sparse_opt = expr(*sparse_views)
 
     # check type is maintained when not using numpy arrays
     assert isinstance(sparse_opt, sparse.COO)
@@ -285,7 +285,7 @@ def test_sparse(string):
     assert np.allclose(ein, sparse_opt.todense())
 
     # try raw contract
-    sparse_opt = contract(string, *sparse_views, backend='sparse')
+    sparse_opt = contract(string, *sparse_views)
     assert isinstance(sparse_opt, sparse.COO)
     assert np.allclose(ein, sparse_opt.todense())
 
@@ -305,7 +305,7 @@ def test_torch(string):
 
     # test non-conversion mode
     torch_views = [backends.to_torch(view) for view in views]
-    torch_opt = expr(*torch_views, backend='torch')
+    torch_opt = expr(*torch_views)
     assert isinstance(torch_opt, torch.Tensor)
     assert np.allclose(ein, torch_opt.cpu().numpy())
 
@@ -333,7 +333,7 @@ def test_torch_with_constants():
     assert np.allclose(res_exp, res_got2)
 
     # check torch call returns torch still
-    res_got3 = expr(backends.to_torch(var), backend='torch')
+    res_got3 = expr(backends.to_torch(var))
     assert isinstance(res_got3, torch.Tensor)
     res_got3 = res_got3.numpy() if res_got3.device.type == 'cpu' else res_got3.cpu().numpy()
     assert np.allclose(res_exp, res_got3)


### PR DESCRIPTION
## Description
This implements ``backend='auto'`` for contractions and makes it the default. This works currently by inferring the module from the class of the first array supplied. A slight detail is that sometimes the module of an array does not supply ``tensordot`` etc. (maybe it has subclassed just ``numpy.ndarray`` for example) and in this case ``'numpy'`` is still used.

Hopefully this kind of thing will eventually be made redundant by ``__array_function__`` (#46) but for the moment it makes it a bit more convenient to work with other array libraries.

## Status
- [x] Ready to go