### PR TITLE
Setup: Restricts to Python 3.5+ only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ if __name__ == "__main__":
         url="https://github.com/dgasmith/opt_einsum",
         license='MIT',
         packages=setuptools.find_packages(),
+        python_requires='>=3.5',
         install_requires=[
             'numpy>=1.7',
         ],


### PR DESCRIPTION
## Description
This is a bug where `opt_einsum` was not correctly bound to Python 3.5+. We will need to 1) make a 3.0.1 release and 2) remove the 3.0.0 release from PyPI for this to get into full effect.

@jcmgray Please review ASAP. Happy to also patch the `optimal` path for 3.0.1 if we can get this in today.

## Status
- [x] Ready to go