### PR TITLE
add mars support via alias

### DIFF
--- a/opt_einsum/backends/dispatch.py
+++ b/opt_einsum/backends/dispatch.py
@@ -23,6 +23,7 @@ _aliases = {
     'torch': 'opt_einsum.backends.torch',
     'jax': 'jax.numpy',
     'autograd': 'autograd.numpy',
+    'mars': 'mars.tensor',
 }
 
 


### PR DESCRIPTION
## Description
Add support for [mars](https://github.com/mars-project/mars) (just needs a simple alias), a library a bit similar to `dask`.

## Status
- [x] Ready to go