### PR TITLE
PyPI Stats Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![codecov](https://codecov.io/gh/dgasmith/opt_einsum/branch/master/graph/badge.svg)](https://codecov.io/gh/dgasmith/opt_einsum)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/opt_einsum/badges/version.svg)](https://anaconda.org/conda-forge/opt_einsum)
 [![PyPI](https://img.shields.io/pypi/v/opt_einsum.svg)](https://pypi.org/project/opt-einsum/#description)
+[![PyPIStats](https://img.shields.io/pypi/dm/opt_einsum)](https://pypistats.org/packages/opt-einsum)
 [![Documentation Status](https://readthedocs.org/projects/optimized-einsum/badge/?version=latest)](http://optimized-einsum.readthedocs.io/en/latest/?badge=latest)
 [![DOI](http://joss.theoj.org/papers/10.21105/joss.00753/status.svg)](https://doi.org/10.21105/joss.00753)
 


### PR DESCRIPTION
## Description
We seem to have hit a new level of 1.5M+ downloads/month which is quite something. I thought it might be nice to add a badge to show this off.

As a side note does anyone know which package we went into early October which caused the spike? I think the underscore in the package name is preventing GitHub from correctly finding dependencies and I am unsure how to track it through PyPI or Conda without construct the full dependency tree locally. 

At this scale it would be good to be in contact with all downstream packages like we are with Pyro.

## Status
- [x] Ready to go