### PR TITLE
updates to 'dp' optimizer

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -19,3 +19,4 @@ Function Reference
     opt_einsum.paths.BranchBound
     opt_einsum.path_random.RandomOptimizer
     opt_einsum.path_random.RandomGreedy
+    opt_einsum.paths.DynamicProgramming

--- a/docs/source/dp_path.rst
+++ b/docs/source/dp_path.rst
@@ -23,9 +23,9 @@ complexity of finding the contraction path is drastically reduced: If the
 subgraphs consist of ``n1``, ``n2``, ... inputs, the computational complexity
 is reduced from ``O(exp(n1 + n2 + ...))`` to ``O(exp(n1) + exp(n2) + ...)``.
 
-The DP approach will only perform pair contractions and will never compute
-intermediate outer products as in reference [1] it is shown that this always
-results in an asymptotically optimal contraction path.
+The DP approach will only perform pair contractions and by default will never
+compute intermediate outer products as in reference [1] it is shown that this
+always results in an asymptotically optimal contraction path.
 
 A major optimization for DP is the cost capping strategy: The DP optimization
 only memorizes contractions for a subset of inputs, if the total cost for this
@@ -41,5 +41,30 @@ contraction graphs and is guaranteed to find an asymptotically optimal
 contraction path. For this reason it is the most frequently used contraction
 path optimizer in the field of tensor network states.
 
+More specifically, the search is performed over connected subgraphs, which, for
+example, planar and tree-like graphs have far fewer of. As a rough guide, if
+the graph is planar, expressions with many tens of tensors are tractable,
+whereas if the graph is tree-like, expressions with many hundreds of tensors
+are tractable.
+
 
 [1] Robert N. C. Pfeifer, Jutho Haegeman, and Frank Verstraete Phys. Rev. E 90, 033315 (2014). https://arxiv.org/abs/1304.6112
+
+
+Customizing the Dynamic Programming Path
+----------------------------------------
+
+The default ``optimize='dp'`` approach has sensible defaults but can be
+customized with the :class:`~opt_einsum.paths.DynamicProgramming` object.
+
+.. code:: python
+
+    import opt_einsum as oe
+
+    optimizer = oe.DynamicProgramming(
+        minimize='size',    # optimize for size (rather than FLOPs)
+        search_outer=True,  # search through outer products as well
+        cost_cap=False,     # don't use cost-capping strategy
+    )
+
+    oe.contract(eq, *arrays, optimize=optimizer)

--- a/docs/source/dp_path.rst
+++ b/docs/source/dp_path.rst
@@ -68,3 +68,8 @@ customized with the :class:`~opt_einsum.paths.DynamicProgramming` object.
     )
 
     oe.contract(eq, *arrays, optimize=optimizer)
+
+.. warning::
+
+    Note that searching outer products will most likely drastically slow down
+    the optimizer on all but the smallest examples.

--- a/docs/source/dp_path.rst
+++ b/docs/source/dp_path.rst
@@ -62,7 +62,7 @@ customized with the :class:`~opt_einsum.paths.DynamicProgramming` object.
     import opt_einsum as oe
 
     optimizer = oe.DynamicProgramming(
-        minimize='size',    # optimize for size (rather than FLOPs)
+        minimize='size',    # optimize for largest intermediate tensor size
         search_outer=True,  # search through outer products as well
         cost_cap=False,     # don't use cost-capping strategy
     )

--- a/opt_einsum/__init__.py
+++ b/opt_einsum/__init__.py
@@ -9,7 +9,7 @@ from . import path_random
 from .contract import contract, contract_path, contract_expression
 from .parser import get_symbol
 from .sharing import shared_intermediates
-from .paths import BranchBound
+from .paths import BranchBound, DynamicProgramming
 from .path_random import RandomGreedy
 
 # Handle versioneer

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -6,7 +6,7 @@ import functools
 import heapq
 import itertools
 import random
-from collections import defaultdict
+from collections import defaultdict, Counter
 
 import numpy as np
 
@@ -14,7 +14,7 @@ from . import helpers
 
 __all__ = [
     "optimal", "BranchBound", "branch", "greedy", "auto", "auto_hq",
-    "get_path_fn", "DynamicProgrammingOptimizer", "dynamic_programming"
+    "get_path_fn", "DynamicProgramming", "dynamic_programming"
 ]
 
 
@@ -761,38 +761,77 @@ def _find_disconnected_subgraphs(inputs, output):
     return subgraphs
 
 
-def _bitmapset_indices(s):
+def _bitmap_select(s, seq):
+    """Select elements of ``seq`` which are marked by the bitmap set ``s``.
+
+    E.g.:
+
+        >>> list(_bitmap_select(0b11010, ['A', 'B', 'C', 'D', 'E']))
+        ['B', 'D', 'E']
     """
-    Returns a generator object allowing to iterate over the elements contained
-    in a bitmap set.
+    return (x for x, b in zip(seq, bin(s)[:1:-1]) if b == '1')
 
-    Parameters
-    ----------
-    s : int
-        The bitmap set to iterate over
 
-    Returns
-    -------
-    path : generator
-        Generator object to iterate over the elements in s
+def _dp_compare_flops(cost1, cost2, i1_union_i2, size_dict, cost_cap, s1, s2, xn, g,
+                      all_tensors, inputs, i1_cut_i2_wo_output, memory_limit, cntrct1, cntrct2):
+    cost = cost1 + cost2 + helpers.compute_size_by_dict(i1_union_i2, size_dict)
+    if cost <= cost_cap:
+        s = s1 | s2
+        if s not in xn or cost < xn[s][1]:
+            # set of remaining tensors (=g-s)
+            r = g & (all_tensors ^ s)
 
-    Examples
-    --------
-    >>> type(_bitmapset_indices(0b1001011))
-    generator
+            # indices of remaining indices:
+            if r:
+                i_r = set.union(*_bitmap_select(r, inputs))
+            else:
+                i_r = set()
 
-    >>> list(_bitmapset_indices(0b1001011))
-    [0, 1, 3, 6]
+            # contraction indices:
+            i_cntrct = i1_cut_i2_wo_output - i_r
+
+            i = i1_union_i2 - i_cntrct
+            mem = helpers.compute_size_by_dict(i, size_dict)
+            if memory_limit is None or mem <= memory_limit:
+                xn[s] = (i, cost, (cntrct1, cntrct2))
+
+
+def _dp_compare_size(cost1, cost2, i1_union_i2, size_dict, cost_cap, s1, s2, xn, g,
+                     all_tensors, inputs, i1_cut_i2_wo_output, memory_limit, cntrct1, cntrct2):
+    s = s1 | s2
+    r = g & (all_tensors ^ s)
+
+    # indices of remaining indices:
+    if r:
+        i_r = set.union(*_bitmap_select(r, inputs))
+    else:
+        i_r = set()
+
+    # contraction indices:
+    i_cntrct = i1_cut_i2_wo_output - i_r
+
+    i = i1_union_i2 - i_cntrct
+    mem = helpers.compute_size_by_dict(i, size_dict)
+
+    cost = max(cost1, cost2, mem)
+    if cost <= cost_cap:
+        if s not in xn or cost < xn[s][1]:
+            # set of remaining tensors (=g-s)
+            if memory_limit is None or mem <= memory_limit:
+                xn[s] = (i, cost, (cntrct1, cntrct2))
+
+
+def simple_tree_tuple(seq):
+    """Make a simple left to right binary tree out of iterable ``seq``.
+
+        >>> tuple_nest([1, 2, 3, 4])
+        (((1, 2), 3), 4)
+
     """
-    j = 0
-    while s != 0:
-        if s & 1 != 0:
-            yield j
-        s >>= 1
-        j += 1
+    return functools.reduce(lambda x, y: (x, y), seq)
 
 
-class DynamicProgrammingOptimizer(PathOptimizer):
+class DynamicProgramming(PathOptimizer):
     """
     Finds the optimal path of pairwise contractions without intermediate outer
     products based a dynamic programming approach presented in
@@ -806,7 +845,42 @@ class DynamicProgrammingOptimizer(PathOptimizer):
     contracted consists of disconnected subgraphs, the algorithm scales
     linearly in the number of disconnected subgraphs and only exponentially
     with the number of inputs per subgraph.
+
+    Parameters
+    ----------
+    minimize : {'flops', 'size'}, optional
+        Whether to find the contraction that minimizes the number of
+        operations or the size of the largest intermediate tensor.
+    cost_cap : {True, False, int}, optional
+        How to implement cost-capping:
+
+            * True - iteratively increase the cost-cap
+            * False - implement no cost-cap at all
+            * int - use explicit cost cap
+
+    search_outer : bool, optional
+        In rare rare circumstances the optimal contraction may involve an outer
+        product, this option allows searching such contractions but may well
+        slow down the path finding considerably on all but very small graphs.
     """
+
+    def __init__(self, minimize='flops', cost_cap=True, search_outer=False):
+
+        # set whether inner function minimizes against flops or size
+        self.minimize = minimize
+        self._check_contraction = {
+            'flops': _dp_compare_flops,
+            'size': _dp_compare_size,
+        }[self.minimize]
+
+        # set whether inner function considers outer products
+        self.search_outer = search_outer
+        self._check_outer = {
+            False: lambda x: x,
+            True: lambda x: True,
+        }[self.search_outer]
+
+        self.cost_cap = cost_cap
 
     def __call__(self, inputs, output, size_dict, memory_limit=None):
         """
@@ -841,53 +915,57 @@ class DynamicProgrammingOptimizer(PathOptimizer):
         >>>             i[k].add(c)
         >>>             s[c] = 2
         >>>     i_all.extend(i)
-        >>> o = DynamicProgrammingOptimizer()
+        >>> o = DynamicProgramming()
         >>> o(i_all, set(), s)
         [(1, 2), (0, 4), (1, 2), (0, 2), (0, 1)]
         """
+        ind_counts = Counter(itertools.chain(*inputs, output))
+        all_inds = tuple(ind_counts)
 
         # convert all indices to integers (makes set operations ~10 % faster)
-        symbol2int = {c: j for j, c in enumerate(set.union(*inputs) | output)}
+        symbol2int = {c: j for j, c in enumerate(all_inds)}
         inputs = [set(symbol2int[c] for c in i) for i in inputs]
         output = set(symbol2int[c] for c in output)
         size_dict = {symbol2int[c]: v for c, v in size_dict.items() if c in symbol2int}
         size_dict = [size_dict[j] for j in range(len(size_dict))]
 
-        # all summation indices occurring exactly in one input:
-        i_single = set(
-            c for c in set.union(*inputs) - output
-            if sum(1 for i in inputs if c in i) == 1
-        )
+        # parse all summation indices occurring exactly in one input
+        i_single = {i for i, c in enumerate(all_inds) if ind_counts[c] == 1}
+        enum_inputs = enumerate(inputs)
+        inputs, inputs_done, inputs_contractions = [], [], []
+        for j, i in enum_inputs:
+            i_reduced = i - i_single
+            if not i_reduced:
+                # input reduced to scalar already - remove
+                inputs_done.append((j,))
+            else:
+                # if the input has any index reductions, add single contraction
+                inputs.append(i_reduced)
+                inputs_contractions.append((j,) if i_reduced != i else j)
 
-        # contraction expressions for all inputs that have already been
-        # reduced to scalars:
-        inputs_done = [
-            (j,) for j, i in enumerate(inputs)
-            if len(i - i_single) == 0
-        ]
-
-        # remaining input index sets and corresponding contraction expressions;
-        # indices from i_single are removed and if a single-tensor contraction
-        # is performed, the contraction expression is (j,) instead of j;
-        inputs, inputs_contractions = zip(*[
-            (i - i_single, j if i.isdisjoint(i_single) else (j,))
-            for j, i in enumerate(inputs)
-            if len(i - i_single) > 0
-        ])
+        if not inputs:
+            # nothing left to do after single axis reductions!
+            return _tree_to_sequence(simple_tree_tuple(inputs_done))
 
         # a list of all neccessary contraction expressions for each of the
         # disconnected subgraphs and their size
         subgraph_contractions = inputs_done
-        subgraph_contractions_size = [1]*len(inputs_done)
+        subgraph_contractions_size = [1] * len(inputs_done)
 
-        for g in _find_disconnected_subgraphs(inputs, output):
+        if self.search_outer:
+            # optimize everything together if we are considering outer products
+            subgraphs = [set(range(len(inputs)))]
+        else:
+            subgraphs = _find_disconnected_subgraphs(inputs, output)
+
+        for g in subgraphs:
 
             # dynamic programming approach to compute x[n] for subgraph g;
             # x[n][set of n tensors] = (indices, cost, contraction)
             # the set of n tensors is represented by a bitmap: if bit j is 1,
             # tensor j is in the set, e.g. 0b100101 = {0,2,5}; set unions
             # (intersections) can then be computed by bitwise or (and);
-            x = [None]*2 + [dict() for j in range(len(g)-1)]
+            x = [None] * 2 + [dict() for j in range(len(g) - 1)]
             x[1] = {1 << j: (inputs[j], 0, inputs_contractions[j]) for j in g}
 
             # convert set of tensors g to a bitmap set:
@@ -902,10 +980,15 @@ class DynamicProgrammingOptimizer(PathOptimizer):
             # cost_cap successively if no such contraction is found;
             # this is a major performance improvement; start with product of
             # output index dimensions as initial cost_cap
-            cost_cap = helpers.compute_size_by_dict(
-                set.union(*(inputs[j] for j in _bitmapset_indices(g))) & output,
-                size_dict
-            )
+            if self.cost_cap is True:
+                cost_cap = helpers.compute_size_by_dict(set.union(*_bitmap_select(g, inputs)) & output, size_dict)
+            elif self.cost_cap is False:
+                cost_cap = float('inf')
+            else:
+                cost_cap = self.cost_cap
+
+            # set the factor to increase the cost by each iteration (keep > 1)
+            cost_increment = max(min(map(size_dict.__getitem__, set.union(*_bitmap_select(g, inputs)))), 2)
 
             while len(x[-1]) == 0:
                 for n in range(2, len(x[1]) + 1):
@@ -914,41 +997,27 @@ class DynamicProgrammingOptimizer(PathOptimizer):
                     # try to combine solutions from x[m] and x[n-m]
                     for m in range(1, n // 2 + 1):
                         for s1, (i1, cost1, cntrct1) in x[m].items():
-                            for s2, (i2, cost2, cntrct2) in x[n-m].items():
+                            for s2, (i2, cost2, cntrct2) in x[n - m].items():
 
                                 # only if s1 and s2 are disjoint
-                                if s1 & s2 == 0:
+                                if not s1 & s2:
 
                                     # avoid e.g. s1={0}, s2={1} and s1={1}, s2={0}
                                     if m != n - m or s1 < s2:
 
                                         i1_cut_i2_wo_output = (i1 & i2) - output
 
-                                        # ignore outer products:
-                                        if len(i1_cut_i2_wo_output) > 0:
+                                        # maybe ignore outer products:
+                                        if self._check_outer(i1_cut_i2_wo_output):
 
                                             i1_union_i2 = i1 | i2
-                                            cost = cost1 + cost2 + helpers.compute_size_by_dict(i1_union_i2, size_dict)
-                                            if cost <= cost_cap:
-                                                s = s1 | s2
-                                                if s not in xn or cost < xn[s][1]:
-                                                    # set of remaining tensors (=g-s)
-                                                    r = g & (all_tensors ^ s)
-
-                                                    # indices of remaining indices:
-                                                    i_r = (set.union(*(inputs[j] for j in _bitmapset_indices(r)))
-                                                           if r != 0 else set())
-
-                                                    # contraction indices:
-                                                    i_cntrct = i1_cut_i2_wo_output - i_r
-
-                                                    i = i1_union_i2 - i_cntrct
-                                                    mem = helpers.compute_size_by_dict(i, size_dict)
-                                                    if memory_limit is None or mem <= memory_limit:
-                                                        xn[s] = (i, cost, (cntrct1, cntrct2))
+                                            self._check_contraction(
+                                                cost1, cost2, i1_union_i2, size_dict, cost_cap, s1,
+                                                s2, xn, g, all_tensors, inputs, i1_cut_i2_wo_output,
+                                                memory_limit, cntrct1, cntrct2)
 
                 # increase cost cap for next iteration:
-                cost_cap = min(size_dict) * cost_cap
+                cost_cap = cost_increment * cost_cap
 
             i, cost, contraction = list(x[-1].values())[0]
             subgraph_contractions.append(contraction)
@@ -959,17 +1028,16 @@ class DynamicProgrammingOptimizer(PathOptimizer):
         # outer products should be performed pairwise (to use BLAS functions)
         subgraph_contractions = [
             subgraph_contractions[j]
-            for j in np.argsort(subgraph_contractions_size)
+            for j in sorted(range(len(subgraph_contractions_size)), key=subgraph_contractions_size.__getitem__)
         ]
 
         # build the final contraction tree
-        tree = functools.reduce(lambda x, y: (x, y), subgraph_contractions)
-
+        tree = simple_tree_tuple(subgraph_contractions)
         return _tree_to_sequence(tree)
 
 
-def dynamic_programming(inputs, output, size_dict, memory_limit=None):
-    optimizer = DynamicProgrammingOptimizer()
+def dynamic_programming(inputs, output, size_dict, memory_limit=None, **kwargs):
+    optimizer = DynamicProgramming(**kwargs)
     return optimizer(inputs, output, size_dict, memory_limit)
 
 

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -772,7 +772,7 @@ def _bitmap_select(s, seq):
     return (x for x, b in zip(seq, bin(s)[:1:-1]) if b == '1')
 
 
-def _dp_calc_legs(g, all_tensors, s, inputs_contract, i1_cut_i2_wo_output, i1_union_i2):
+def _dp_calc_legs(g, all_tensors, s, inputs, i1_cut_i2_wo_output, i1_union_i2):
     """Calculates the effective outer indices of the intermediate tensor
     corresponding to the subgraph ``s``.
     """
@@ -780,7 +780,7 @@ def _dp_calc_legs(g, all_tensors, s, inputs_contract, i1_cut_i2_wo_output, i1_un
     r = g & (all_tensors ^ s)
     # indices of remaining indices:
     if r:
-        i_r = set.union(*_bitmap_select(r, inputs_contract))
+        i_r = set.union(*_bitmap_select(r, inputs))
     else:
         i_r = set()
     # contraction indices:
@@ -789,7 +789,7 @@ def _dp_calc_legs(g, all_tensors, s, inputs_contract, i1_cut_i2_wo_output, i1_un
 
 
 def _dp_compare_flops(cost1, cost2, i1_union_i2, size_dict, cost_cap, s1, s2, xn, g, all_tensors,
-                      inputs_contract, i1_cut_i2_wo_output, memory_limit, cntrct1, cntrct2):
+                      inputs, i1_cut_i2_wo_output, memory_limit, cntrct1, cntrct2):
     """Performs the inner comparison of whether the two subgraphs (the bitmaps
     ``s1`` and ``s2``) should be merged and added to the dynamic programming
     search. Will skip for a number of reasons:
@@ -804,20 +804,20 @@ def _dp_compare_flops(cost1, cost2, i1_union_i2, size_dict, cost_cap, s1, s2, xn
     if cost <= cost_cap:
         s = s1 | s2
         if s not in xn or cost < xn[s][1]:
-            i = _dp_calc_legs(g, all_tensors, s, inputs_contract, i1_cut_i2_wo_output, i1_union_i2)
+            i = _dp_calc_legs(g, all_tensors, s, inputs, i1_cut_i2_wo_output, i1_union_i2)
             mem = helpers.compute_size_by_dict(i, size_dict)
             if memory_limit is None or mem <= memory_limit:
                 xn[s] = (i, cost, (cntrct1, cntrct2))
 
 
 def _dp_compare_size(cost1, cost2, i1_union_i2, size_dict, cost_cap, s1, s2, xn, g, all_tensors,
-                     inputs_contract, i1_cut_i2_wo_output, memory_limit, cntrct1, cntrct2):
+                     inputs, i1_cut_i2_wo_output, memory_limit, cntrct1, cntrct2):
     """Like ``_dp_compare_flops`` but sieves the potential contraction based
     on the size of the intermediate tensor created, rather than the number of
     operations, and so calculates that first.
     """
     s = s1 | s2
-    i = _dp_calc_legs(g, all_tensors, s, inputs_contract, i1_cut_i2_wo_output, i1_union_i2)
+    i = _dp_calc_legs(g, all_tensors, s, inputs, i1_cut_i2_wo_output, i1_union_i2)
     mem = helpers.compute_size_by_dict(i, size_dict)
     cost = max(cost1, cost2, mem)
     if cost <= cost_cap:
@@ -834,6 +834,29 @@ def simple_tree_tuple(seq):
 
     """
     return functools.reduce(lambda x, y: (x, y), seq)
+
+
+def _dp_parse_out_single_term_ops(inputs, all_inds, ind_counts):
+    """Take ``inputs`` and parse for single term index operations, i.e. where
+    an index appears on one tensor and nowhere else.
+
+    If a term is completely reduced to a scalar in this way it can be removed
+    to ``inputs_done``. If only some indices can be summed then add a 'single
+    term contraction' that will perform this summation.
+    """
+    i_single = {i for i, c in enumerate(all_inds) if ind_counts[c] == 1}
+    inputs_parsed, inputs_done, inputs_contractions = [], [], []
+    for j, i in enumerate(inputs):
+        i_reduced = i - i_single
+        if not i_reduced:
+            # input reduced to scalar already - remove
+            inputs_done.append((j,))
+        else:
+            # if the input has any index reductions, add single contraction
+            inputs_parsed.append(i_reduced)
+            inputs_contractions.append((j,) if i_reduced != i else j)
+
+    return inputs_parsed, inputs_done, inputs_contractions
 
 
 class DynamicProgramming(PathOptimizer):
@@ -934,20 +957,9 @@ class DynamicProgramming(PathOptimizer):
         size_dict = {symbol2int[c]: v for c, v in size_dict.items() if c in symbol2int}
         size_dict = [size_dict[j] for j in range(len(size_dict))]
 
-        # parse all summation indices occurring exactly in one input
-        i_single = {i for i, c in enumerate(all_inds) if ind_counts[c] == 1}
-        inputs_contract, inputs_done, inputs_contractions = [], [], []
-        for j, i in enumerate(inputs):
-            i_reduced = i - i_single
-            if not i_reduced:
-                # input reduced to scalar already - remove
-                inputs_done.append((j,))
-            else:
-                # if the input has any index reductions, add single contraction
-                inputs_contract.append(i_reduced)
-                inputs_contractions.append((j,) if i_reduced != i else j)
+        inputs, inputs_done, inputs_contractions = _dp_parse_out_single_term_ops(inputs, all_inds, ind_counts)
 
-        if not inputs_contract:
+        if not inputs:
             # nothing left to do after single axis reductions!
             return _tree_to_sequence(simple_tree_tuple(inputs_done))
 
@@ -958,14 +970,14 @@ class DynamicProgramming(PathOptimizer):
 
         if self.search_outer:
             # optimize everything together if we are considering outer products
-            subgraphs = [set(range(len(inputs_contract)))]
+            subgraphs = [set(range(len(inputs)))]
         else:
-            subgraphs = _find_disconnected_subgraphs(inputs_contract, output)
+            subgraphs = _find_disconnected_subgraphs(inputs, output)
 
         # the bitmap set of all tensors is computed as it is needed to
         # compute set differences: s1 - s2 transforms into
         # s1 & (all_tensors ^ s2)
-        all_tensors = (1 << len(inputs_contract)) - 1
+        all_tensors = (1 << len(inputs)) - 1
 
         for g in subgraphs:
 
@@ -975,7 +987,7 @@ class DynamicProgramming(PathOptimizer):
             # tensor j is in the set, e.g. 0b100101 = {0,2,5}; set unions
             # (intersections) can then be computed by bitwise or (and);
             x = [None] * 2 + [dict() for j in range(len(g) - 1)]
-            x[1] = {1 << j: (inputs_contract[j], 0, inputs_contractions[j]) for j in g}
+            x[1] = {1 << j: (inputs[j], 0, inputs_contractions[j]) for j in g}
 
             # convert set of tensors g to a bitmap set:
             g = functools.reduce(lambda x, y: x | y, (1 << j for j in g))
@@ -984,7 +996,7 @@ class DynamicProgramming(PathOptimizer):
             # cost_cap successively if no such contraction is found;
             # this is a major performance improvement; start with product of
             # output index dimensions as initial cost_cap
-            subgraph_inds = set.union(*_bitmap_select(g, inputs_contract))
+            subgraph_inds = set.union(*_bitmap_select(g, inputs))
             if self.cost_cap is True:
                 cost_cap = helpers.compute_size_by_dict(subgraph_inds & output, size_dict)
             elif self.cost_cap is False:
@@ -1014,7 +1026,7 @@ class DynamicProgramming(PathOptimizer):
                                         i1_union_i2 = i1 | i2
                                         self._check_contraction(
                                             cost1, cost2, i1_union_i2, size_dict, cost_cap, s1,
-                                            s2, xn, g, all_tensors, inputs_contract, i1_cut_i2_wo_output,
+                                            s2, xn, g, all_tensors, inputs, i1_cut_i2_wo_output,
                                             memory_limit, cntrct1, cntrct2)
 
                 # increase cost cap for next iteration:


### PR DESCRIPTION
## Description
These updates the ``'dp'`` optimizer in a few ways:
- fixes some edge case bugs (#116, #118) @yaroslavvb
- allows it to be customized in a few ways (without any impact on performance in the default case):
    * whether to target minimum flop count or minimize size
    * whether to search through outer products
    * how to set the ``cost_cap`` iterate strategy (on, off or manual)
- a few tweaks to make the overhead lower for small contractions particularly
- renames ``DynamicProgrammingOptimizer->DynamicProgramming`` and add it to the top namespace

I think with these, it would make sense to make the ``'optimal'`` algorithm point at ``'dp'`` since with the outer product search it should now find all the same contractions, and with the ``cost_cap`` turned off it's as fast for small contractions as well. This would fix #99. Thoughts @dgasmith? Also cc @mrader1248.

## Todos
  - [x] document customizable `DynamicProgramming`
  - [ ] one could identify now 'standard tensor network' contractions (i.e. every index appears exactly twice) at the beginning from the index count, and possibly switch to a faster method for computing resulting indices (simply the symmetric difference of inputs)
  - [ ] use a version of ``'dp'`` for ``'optimal'``?
  - [ ] have an ``'auto'``value for the `cost_cap` that simply turns it off til the contraction is quite big

## Status
- [ ] Ready to go