### PR TITLE
Publish sdist and bdist wheel

### DIFF
--- a/devtools/RELEASE.md
+++ b/devtools/RELEASE.md
@@ -4,7 +4,7 @@
 ```
 conda update setuptools wheel
 
-python setup.py sdist
+python setup.py sdist bdist_wheel
 twine upload --repository-url https://test.pypi.org/legacy/ dist/
 ```
 


### PR DESCRIPTION
## Description
The benefits of wheels are well documented. See: https://pythonwheels.com/
This package is pure Python and publishing it as both source and as a wheel is simple.