### PR TITLE
add python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ if __name__ == "__main__":
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
         ],
         zip_safe=True,
         long_description=long_description,


### PR DESCRIPTION
PyTorch is now released for Python-3.8

## Description
Declare Python-3.8 compatible


## Questions
- [ ] do we need also Tensorflow to be released for Python-3.8 ?

## Status
- [ ] Ready to go