### PR TITLE
Make JAX backend import lazy.

### DIFF
--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -13,7 +13,7 @@ else
     MINICONDA=Miniconda3-latest-Linux-x86_64.sh
 fi
 MINICONDA_HOME=$HOME/miniconda
-MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+MINICONDA_MD5=$(wget -qO- https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 wget -q https://repo.continuum.io/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"


### PR DESCRIPTION
We observed the following surprising behavior: importing tensorflow also imports jax, if installed. This happens because tensorflow has an opt_einsum dependency that is imported eagerly, and the opt_einsum jax backend eagerly imports jax. To avoid this, make the jax import from opt_einsum lazy.

## Status
- [ * ] Ready to go