### PR TITLE
contraction_list: only keep remaining for last 20 contractions

### DIFF
--- a/opt_einsum/backends/jax.py
+++ b/opt_einsum/backends/jax.py
@@ -13,18 +13,18 @@ _JAX = None
 
 
 def _get_jax_and_to_jax():
-  global _JAX
-  if _JAX is None:
-    import jax
+    global _JAX
+    if _JAX is None:
+        import jax
 
-    @to_backend_cache_wrap
-    @jax.jit
-    def to_jax(x):
-        return x
+        @to_backend_cache_wrap
+        @jax.jit
+        def to_jax(x):
+            return x
 
-    _JAX = jax, to_jax
+        _JAX = jax, to_jax
 
-  return _JAX
+    return _JAX
 
 
 def build_expression(_, expr):  # pragma: no cover

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -309,7 +309,9 @@ def contract_path(*operands, **kwargs):
 
         einsum_str = ",".join(tmp_inputs) + "->" + idx_result
 
-        if len(input_list) <= 10:
+        # for large expressions saving the remaining terms at each step can
+        # incur a large memory footprint - and also be messy to print
+        if len(input_list) <= 20:
             remaining = tuple(input_list)
         else:
             remaining = None

--- a/opt_einsum/tests/test_contract.py
+++ b/opt_einsum/tests/test_contract.py
@@ -171,7 +171,7 @@ def test_printing():
     views = helpers.build_views(string)
 
     ein = contract_path(string, *views)
-    assert len(str(ein[1])) == 726
+    assert len(str(ein[1])) == 728
 
 
 @pytest.mark.parametrize("string", tests)

--- a/opt_einsum/tests/test_input.py
+++ b/opt_einsum/tests/test_input.py
@@ -34,7 +34,8 @@ def test_type_errors():
         contract("", 0, out='test')
 
     # order parameter must be a valid order
-    with pytest.raises(TypeError):
+    # changed in Numpy 1.19, see https://github.com/numpy/numpy/commit/35b0a051c19265f5643f6011ee11e31d30c8bc4c
+    with pytest.raises((TypeError, ValueError)):
         contract("", 0, order='W')
 
     # casting parameter must be a valid casting


### PR DESCRIPTION
## Description
Resolves #148, by only keeping the last 10 'remaining terms' lists in the `contraction_list`, which is generally the point it starts to look a bit messy in the `PathInfo` object. This could be tweaked / made customizable.

I've also 
* changed the 'speedup' formatting to scientific as this number can be **very** large sometimes.
* added a few more spaces inbetween the 'current' contraction and 'remaining terms' for clarity (putting them in ``[...]`` might also be clearer.

```python
>>> import opt_einsum as oe
>>> eq, shapes = oe.helpers.rand_equation(20, 3)
>>> path, info = oe.contract_path(eq, *shapes, shapes=True, optimize='greconf')
>>> info
  Complete contraction:  n,aA,jhr,mw,ox,Bos,dc,Cqeu,ipDs,tBk,v,tpkD,u,fram,byqx,znfgd,eCvlbz,icg,jw,yAhl->
         Naive scaling:  30
     Optimized scaling:  6
      Naive FLOP count:  1.680e+21
  Optimized FLOP count:  9.401e+4
   Theoretical speedup:  1.786e+16
  Largest intermediate:  3.888e+3 elements
--------------------------------------------------------------------------------
scaling        BLAS                current                             remaining
--------------------------------------------------------------------------------
   3           GEMM              jw,mw->jm                                   ...
   4           GEMM            jm,jhr->mhr                                   ...
   5           TDOT          mhr,fram->hfa                                   ...
   4           GEMM            hfa,aA->hfA                                   ...
   5    GEMV/EINSUM          znfgd,n->zfgd                                   ...
   4           TDOT            icg,dc->igd                                   ...
   5           GEMM          igd,zfgd->izf                                   ...
   5           TDOT          izf,hfA->izhA                                   ...
   6           TDOT        izhA,yAhl->izyl                                   ...
   5           TDOT          tpkD,tBk->pDB    ox,Bos,Cqeu,ipDs,v,u,byqx,eCvlbz,izyl,pDB->
   5           TDOT          pDB,ipDs->Bis    ox,Bos,Cqeu,v,u,byqx,eCvlbz,izyl,Bis->
   4           TDOT            Bis,Bos->io     ox,Cqeu,v,u,byqx,eCvlbz,izyl,io->
   3           GEMM              io,ox->ix        Cqeu,v,u,byqx,eCvlbz,izyl,ix->
   5           GEMM          ix,byqx->ibyq           Cqeu,v,u,eCvlbz,izyl,ibyq->
   6           TDOT        ibyq,izyl->bqzl                Cqeu,v,u,eCvlbz,bqzl->
   4           GEMM            u,Cqeu->Cqe                   v,eCvlbz,bqzl,Cqe->
   6           TDOT        Cqe,bqzl->Cebzl                      v,eCvlbz,Cebzl->
   6    GEMV/EINSUM        Cebzl,eCvlbz->v                                 v,v->
   1            DOT                  v,v->                                    ->
```


## Status
- [x] Ready to go