### PR TITLE
Small fixes: 'dp' and memory_limit + tensordot axes order

### DIFF
--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -561,14 +561,18 @@ def _core_contract(operands, contraction_list, backend='auto', evaluate_constant
 
             tensor_result = "".join(s for s in input_left + input_right if s not in idx_rm)
 
-            # Find indices to contract over
-            left_pos, right_pos = [], []
-            for s in idx_rm:
-                left_pos.append(input_left.find(s))
-                right_pos.append(input_right.find(s))
+            if idx_rm:
+                # Find indices to contract over
+                left_pos, right_pos = [], []
+                for s in idx_rm:
+                    left_pos.append(input_left.find(s))
+                    right_pos.append(input_right.find(s))
 
-            # Construct the axes tuples in a canonical order
-            axes = tuple(zip(*sorted(zip(left_pos, right_pos))))
+                # Construct the axes tuples in a canonical order
+                axes = tuple(zip(*sorted(zip(left_pos, right_pos))))
+            else:
+                # Ensure axes is always pair of tuples
+                axes = ((), ())
 
             # Contract!
             new_view = _tensordot(*tmp_operands, axes=axes, backend=backend)

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -5,8 +5,6 @@ Contains the primary optimization and contraction routines.
 from collections import namedtuple
 from decimal import Decimal
 
-import numpy as np
-
 from . import backends, blas, helpers, parser, paths, sharing
 
 __all__ = ["contract_path", "contract", "format_const_einsum_str", "ContractExpression", "shape_only"]
@@ -760,7 +758,7 @@ class ContractExpression:
         try:
             # Check if the backend requires special preparation / calling
             #   but also ignore non-numpy arrays -> assume user wants same type back
-            if backends.has_backend(backend) and all(isinstance(x, np.ndarray) for x in arrays):
+            if backends.has_backend(backend) and all(infer_backend(x) == 'numpy' for x in arrays):
                 return self._contract_with_conversion(ops, out, backend, evaluate_constants=evaluate_constants)
 
             return self._contract(ops, out, backend, evaluate_constants=evaluate_constants)

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -569,8 +569,11 @@ def _core_contract(operands, contraction_list, backend='auto', evaluate_constant
                 left_pos.append(input_left.find(s))
                 right_pos.append(input_right.find(s))
 
+            # Contruct the axes tuples in a canonical order
+            axes = tuple(zip(*sorted(zip(left_pos, right_pos))))
+
             # Contract!
-            new_view = _tensordot(*tmp_operands, axes=(tuple(left_pos), tuple(right_pos)), backend=backend)
+            new_view = _tensordot(*tmp_operands, axes=axes, backend=backend)
 
             # Build a new view if needed
             if (tensor_result != results_index) or handle_out:

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -567,7 +567,7 @@ def _core_contract(operands, contraction_list, backend='auto', evaluate_constant
                 left_pos.append(input_left.find(s))
                 right_pos.append(input_right.find(s))
 
-            # Contruct the axes tuples in a canonical order
+            # Construct the axes tuples in a canonical order
             axes = tuple(zip(*sorted(zip(left_pos, right_pos))))
 
             # Contract!

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -1035,7 +1035,7 @@ class DynamicProgramming(PathOptimizer):
                                                                 xn, g, all_tensors, inputs, i1_cut_i2_wo_output,
                                                                 memory_limit, cntrct1, cntrct2)
 
-                if (cost_cap >= naive_cost) and (len(x[-1]) == 0):
+                if (cost_cap > naive_cost) and (len(x[-1]) == 0):
                     raise RuntimeError("No contraction found for given `memory_limit`.")
 
                 # increase cost cap for next iteration:

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -6,6 +6,7 @@ import functools
 import heapq
 import itertools
 import random
+import operator
 from collections import Counter, OrderedDict, defaultdict
 
 import numpy as np
@@ -961,6 +962,7 @@ class DynamicProgramming(PathOptimizer):
         output = set(symbol2int[c] for c in output)
         size_dict = {symbol2int[c]: v for c, v in size_dict.items() if c in symbol2int}
         size_dict = [size_dict[j] for j in range(len(size_dict))]
+        naive_cost = functools.reduce(operator.mul, size_dict)
 
         inputs, inputs_done, inputs_contractions = _dp_parse_out_single_term_ops(inputs, all_inds, ind_counts)
 
@@ -1032,6 +1034,9 @@ class DynamicProgramming(PathOptimizer):
                                         self._check_contraction(cost1, cost2, i1_union_i2, size_dict, cost_cap, s1, s2,
                                                                 xn, g, all_tensors, inputs, i1_cut_i2_wo_output,
                                                                 memory_limit, cntrct1, cntrct2)
+
+                if (cost_cap >= naive_cost) and (len(x[-1]) == 0):
+                    raise RuntimeError("No contraction found for given `memory_limit`.")
 
                 # increase cost cap for next iteration:
                 cost_cap = cost_increment * cost_cap

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -962,7 +962,7 @@ class DynamicProgramming(PathOptimizer):
         output = set(symbol2int[c] for c in output)
         size_dict = {symbol2int[c]: v for c, v in size_dict.items() if c in symbol2int}
         size_dict = [size_dict[j] for j in range(len(size_dict))]
-        naive_cost = functools.reduce(operator.mul, size_dict)
+        naive_cost = len(inputs) * functools.reduce(operator.mul, size_dict)
 
         inputs, inputs_done, inputs_contractions = _dp_parse_out_single_term_ops(inputs, all_inds, ind_counts)
 

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -250,6 +250,22 @@ def test_custom_dp_can_set_cost_cap():
     assert info1.opt_cost == info2.opt_cost == info3.opt_cost
 
 
+def test_dp_errors_when_no_contractions_found():
+    eq, shapes, size_dict = oe.helpers.rand_equation(10, 3, seed=42, return_size_dict=True)
+
+    # first get the actual minimum cost
+    opt = oe.DynamicProgramming(minimize='size')
+    path, info = oe.contract_path(eq, *shapes, shapes=True, optimize=opt)
+    mincost = info.largest_intermediate
+
+    # check we can still find it without minimizing size explicitly
+    oe.contract_path(eq, *shapes, shapes=True, memory_limit=mincost, optimize='dp')
+
+    # but check just below this threshold raises
+    with pytest.raises(RuntimeError):
+        oe.contract_path(eq, *shapes, shapes=True, memory_limit=mincost - 1, optimize='dp')
+
+
 @pytest.mark.parametrize("optimize", ['greedy', 'branch-2', 'branch-all', 'optimal', 'dp'])
 def test_can_optimize_outer_products(optimize):
     a, b, c = [np.random.randn(10, 10) for _ in range(3)]


### PR DESCRIPTION
## Description
This PR:
1. Fixes the bug where a too low ``memory_limit`` meant the ``'dp'`` optimizer would search forever (#153)
2. Puts ``tensordot`` axes in a canonical order (the order they appear on the first operand), so that performance shouldn't change unexpectedly (#143)
3. Changes an ``isinstance`` call to ``infer_backend`` (is cleaner? and fixes a rare bug when mixing inputs for e.g. jax compiled contraction)

## Status
- [x] Ready to go