### PR TITLE
Python Type Annotations

### DIFF
--- a/.github/workflows/Linting.yml
+++ b/.github/workflows/Linting.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Linting
 
 on:
   push:
@@ -7,13 +7,13 @@ on:
     branches: master
 
 jobs:
-  miniconda-setup:
-    name: Env (${{ matrix.environment }}) - Py${{ matrix.python-version }}
+  mypy:
+    name: MyPy
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7]
-        environment: ["min-deps", "full", "min-ver"]
+        python-version: [3.7]
+        environment: ["min-deps"]
 
     runs-on: ubuntu-latest
 
@@ -41,17 +41,32 @@ jobs:
       run: |
         python -m pip install . --no-deps
 
-    - name: Test
+    - name: MyPy
       shell: bash -l {0}
       run: |
-        pytest -v --cov=opt_einsum opt_einsum/ --cov-report=xml
+        mypy opt_einsum
 
-    - name: Coverage
-      shell: bash -l {0}
-      run: |
-        coverage report
+  yapf:
+    name: yapf
+    runs-on: ubuntu-latest
 
-    - uses: codecov/codecov-action@v1
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Python Setup
+      uses: actions/setup-python@v2.2.1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./coverage.xml
+        python-version: 3.8
+
+    - name: Create Environment
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install yapf
+
+    - name: Lint
+      shell: bash
+      run: |
+        set -e
+        echo "Checking formatting for $GITHUB_REPOSITORY"
+        sh -c "yapf --diff --recursive opt_einsum $*"

--- a/.github/workflows/Linting.yml
+++ b/.github/workflows/Linting.yml
@@ -69,4 +69,5 @@ jobs:
       run: |
         set -e
         echo "Checking formatting for $GITHUB_REPOSITORY"
+        yapf --diff --recursive opt_einsum
         sh -c "yapf --diff --recursive opt_einsum $*"

--- a/devtools/conda-envs/full-environment.yaml
+++ b/devtools/conda-envs/full-environment.yaml
@@ -20,4 +20,4 @@ dependencies:
   - pytest
   - codecov
   - pytest-cov
-
+  - mypy ==0.812

--- a/devtools/conda-envs/min-deps-environment.yaml
+++ b/devtools/conda-envs/min-deps-environment.yaml
@@ -11,3 +11,4 @@ dependencies:
   - pytest
   - codecov
   - pytest-cov
+  - mypy ==0.812

--- a/devtools/conda-envs/min-ver-environment.yaml
+++ b/devtools/conda-envs/min-ver-environment.yaml
@@ -15,3 +15,4 @@ dependencies:
   - pytest
   - codecov
   - pytest-cov
+  - mypy ==0.812

--- a/opt_einsum/__init__.py
+++ b/opt_einsum/__init__.py
@@ -10,7 +10,7 @@ from .paths import BranchBound, DynamicProgramming
 from .sharing import shared_intermediates
 
 # Handle versioneer
-from ._version import get_versions # isort:skip
+from ._version import get_versions  # isort:skip
 
 versions = get_versions()
 __version__ = versions['version']

--- a/opt_einsum/__init__.py
+++ b/opt_einsum/__init__.py
@@ -2,18 +2,15 @@
 Main init function for opt_einsum.
 """
 
-from . import blas
-from . import helpers
-from . import paths
-from . import path_random
-from .contract import contract, contract_path, contract_expression
+from . import blas, helpers, path_random, paths
+from .contract import contract, contract_expression, contract_path
 from .parser import get_symbol
-from .sharing import shared_intermediates
-from .paths import BranchBound, DynamicProgramming
 from .path_random import RandomGreedy
+from .paths import BranchBound, DynamicProgramming
+from .sharing import shared_intermediates
 
 # Handle versioneer
-from ._version import get_versions
+from ._version import get_versions # isort:skip
 
 versions = get_versions()
 __version__ = versions['version']

--- a/opt_einsum/backends/__init__.py
+++ b/opt_einsum/backends/__init__.py
@@ -4,7 +4,7 @@ Compute backends for opt_einsum.
 
 # Backends
 from .cupy import to_cupy
-from .dispatch import (get_func, has_einsum, has_tensordot, build_expression, evaluate_constants, has_backend)
+from .dispatch import build_expression, evaluate_constants, get_func, has_backend, has_einsum, has_tensordot
 from .tensorflow import to_tensorflow
 from .theano import to_theano
 from .torch import to_torch

--- a/opt_einsum/backends/dispatch.py
+++ b/opt_einsum/backends/dispatch.py
@@ -5,8 +5,10 @@ constants.
 """
 
 import importlib
+from typing import Dict, List, Sequence
 
 import numpy
+import numpy.typing as npt
 
 from . import cupy as _cupy
 from . import jax as _jax
@@ -28,7 +30,7 @@ _aliases = {
 }
 
 
-def _import_func(func, backend, default=None):
+def _import_func(func: str, backend: str, default=None):
     """Try and import ``{backend}.{func}``.
     If library is installed and func is found, return the func;
     otherwise if default is provided, return default;
@@ -57,7 +59,7 @@ _cached_funcs = {
 }
 
 
-def get_func(func, backend='numpy', default=None):
+def get_func(func: str, backend: str = 'numpy', default=None):
     """Return ``{backend}.{func}``, e.g. ``numpy.einsum``,
     or a default func if provided. Cache result.
     """
@@ -70,10 +72,10 @@ def get_func(func, backend='numpy', default=None):
 
 
 # mark libs with einsum, else try to use tensordot/transpose as much as possible
-_has_einsum = {}
+_has_einsum: Dict[str, bool] = {}
 
 
-def has_einsum(backend):
+def has_einsum(backend: str) -> bool:
     """Check if ``{backend}.einsum`` exists, cache result for performance.
     """
     try:
@@ -88,10 +90,10 @@ def has_einsum(backend):
         return _has_einsum[backend]
 
 
-_has_tensordot = {}
+_has_tensordot: Dict[str, bool] = {}
 
 
-def has_tensordot(backend):
+def has_tensordot(backend: str) -> bool:
     """Check if ``{backend}.tensordot`` exists, cache result for performance.
     """
     try:
@@ -139,7 +141,7 @@ def evaluate_constants(backend, arrays, expr):
     return EVAL_CONSTS_BACKENDS[backend](arrays, expr)
 
 
-def has_backend(backend):
+def has_backend(backend: str) -> bool:
     """Checks if the backend is known.
     """
     return backend.lower() in CONVERT_BACKENDS

--- a/opt_einsum/backends/dispatch.py
+++ b/opt_einsum/backends/dispatch.py
@@ -5,7 +5,7 @@ constants.
 """
 
 import importlib
-from typing import Dict, List, Sequence, Any
+from typing import Any, Dict
 
 import numpy
 

--- a/opt_einsum/backends/dispatch.py
+++ b/opt_einsum/backends/dispatch.py
@@ -8,9 +8,9 @@ import importlib
 
 import numpy
 
-from . import object_arrays
 from . import cupy as _cupy
 from . import jax as _jax
+from . import object_arrays
 from . import tensorflow as _tensorflow
 from . import theano as _theano
 from . import torch as _torch

--- a/opt_einsum/backends/dispatch.py
+++ b/opt_einsum/backends/dispatch.py
@@ -5,10 +5,9 @@ constants.
 """
 
 import importlib
-from typing import Dict, List, Sequence
+from typing import Dict, List, Sequence, Any
 
 import numpy
-import numpy.typing as npt
 
 from . import cupy as _cupy
 from . import jax as _jax
@@ -30,7 +29,7 @@ _aliases = {
 }
 
 
-def _import_func(func: str, backend: str, default=None):
+def _import_func(func: str, backend: str, default: Any = None) -> Any:
     """Try and import ``{backend}.{func}``.
     If library is installed and func is found, return the func;
     otherwise if default is provided, return default;
@@ -59,7 +58,7 @@ _cached_funcs = {
 }
 
 
-def get_func(func: str, backend: str = 'numpy', default=None):
+def get_func(func: str, backend: str = 'numpy', default: Any = None) -> Any:
     """Return ``{backend}.{func}``, e.g. ``numpy.einsum``,
     or a default func if provided. Cache result.
     """

--- a/opt_einsum/backends/object_arrays.py
+++ b/opt_einsum/backends/object_arrays.py
@@ -2,9 +2,10 @@
 Functions for performing contractions with array elements which are objects.
 """
 
-import numpy as np
 import functools
 import operator
+
+import numpy as np
 
 
 def object_einsum(eq, *arrays):

--- a/opt_einsum/blas.py
+++ b/opt_einsum/blas.py
@@ -2,14 +2,20 @@
 Determines if a contraction can use BLAS or not
 """
 
+from typing import List, Sequence, Set, Tuple, Union
+
 import numpy as np
+import numpy.typing as npt
 
 from . import helpers
 
 __all__ = ["can_blas", "tensor_blas"]
 
 
-def can_blas(inputs, result, idx_removed, shapes=None):
+def can_blas(inputs: List[str],
+             result: str,
+             idx_removed: Set[str],
+             shapes: Sequence[Tuple[int]] = None) -> Union[str, bool]:
     """
     Checks if we can use a BLAS call.
 
@@ -120,7 +126,8 @@ def can_blas(inputs, result, idx_removed, shapes=None):
         return 'TDOT'
 
 
-def tensor_blas(view_left, input_left, view_right, input_right, index_result, idx_removed):
+def tensor_blas(view_left: np.ndarray, input_left: str, view_right: np.ndarray, input_right: str, index_result: str,
+                idx_removed: Set[str]) -> np.ndarray:
     """
     Computes the dot product between two tensors, attempts to use np.dot and
     then tensordot if that fails.

--- a/opt_einsum/blas.py
+++ b/opt_einsum/blas.py
@@ -230,7 +230,8 @@ def tensor_blas(view_left: np.ndarray, input_left: str, view_right: np.ndarray, 
     # Conventional tensordot
     else:
         # Find indices to contract over
-        left_pos, right_pos = (), ()
+        left_pos: Tuple[int, ...] = ()
+        right_pos: Tuple[int, ...] = ()
         for s in idx_removed:
             left_pos += (input_left.find(s), )
             right_pos += (input_right.find(s), )

--- a/opt_einsum/blas.py
+++ b/opt_einsum/blas.py
@@ -5,7 +5,7 @@ Determines if a contraction can use BLAS or not
 from typing import List, Sequence, Set, Tuple, Union
 
 import numpy as np
-import numpy.typing as npt
+from .typing import TensorIndexType
 
 from . import helpers
 
@@ -14,7 +14,7 @@ __all__ = ["can_blas", "tensor_blas"]
 
 def can_blas(inputs: List[str],
              result: str,
-             idx_removed: Set[str],
+             idx_removed: TensorIndexType,
              shapes: Sequence[Tuple[int]] = None) -> Union[str, bool]:
     """
     Checks if we can use a BLAS call.
@@ -127,7 +127,7 @@ def can_blas(inputs: List[str],
 
 
 def tensor_blas(view_left: np.ndarray, input_left: str, view_right: np.ndarray, input_right: str, index_result: str,
-                idx_removed: Set[str]) -> np.ndarray:
+                idx_removed: TensorIndexType) -> np.ndarray:
     """
     Computes the dot product between two tensors, attempts to use np.dot and
     then tensordot if that fails.
@@ -202,8 +202,8 @@ def tensor_blas(view_left: np.ndarray, input_left: str, view_right: np.ndarray, 
     dim_right = helpers.compute_size_by_dict(keep_right, dimension_dict)
     dim_removed = helpers.compute_size_by_dict(idx_removed, dimension_dict)
     tensor_result = input_left + input_right
-    for s in idx_removed:
-        tensor_result = tensor_result.replace(s, "")
+    for sidx in idx_removed:
+        tensor_result = tensor_result.replace(sidx, "")
 
     # This is ugly, but can vastly speed up certain operations
     # Vectordot
@@ -232,9 +232,9 @@ def tensor_blas(view_left: np.ndarray, input_left: str, view_right: np.ndarray, 
         # Find indices to contract over
         left_pos: Tuple[int, ...] = ()
         right_pos: Tuple[int, ...] = ()
-        for s in idx_removed:
-            left_pos += (input_left.find(s), )
-            right_pos += (input_right.find(s), )
+        for fidx in idx_removed:
+            left_pos += (input_left.find(fidx), )
+            right_pos += (input_right.find(fidx), )
         new_view = np.tensordot(view_left, view_right, axes=(left_pos, right_pos))
 
     # Make sure the resulting shape is correct

--- a/opt_einsum/blas.py
+++ b/opt_einsum/blas.py
@@ -2,12 +2,12 @@
 Determines if a contraction can use BLAS or not
 """
 
-from typing import List, Sequence, Set, Tuple, Union
+from typing import List, Sequence, Tuple, Union
 
 import numpy as np
-from .typing import TensorIndexType
 
 from . import helpers
+from .typing import TensorIndexType
 
 __all__ = ["can_blas", "tensor_blas"]
 

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -4,6 +4,7 @@ Contains the primary optimization and contraction routines.
 
 from collections import namedtuple
 from decimal import Decimal
+from typing import Any, List, Optional, Sequence, Tuple
 
 from . import backends, blas, helpers, parser, paths, sharing
 
@@ -41,7 +42,7 @@ class PathInfo(object):
         self.eq = "{}->{}".format(input_subscripts, output_subscript)
         self.largest_intermediate = Decimal(max(size_list))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         # Return the path along with a nice string representation
         header = ("scaling", "BLAS", "current", "remaining")
 
@@ -69,7 +70,7 @@ class PathInfo(object):
         return "".join(path_print)
 
 
-def _choose_memory_arg(memory_limit, size_list):
+def _choose_memory_arg(memory_limit: int, size_list: List[int]) -> Optional[int]:
     if memory_limit == 'max_input':
         return max(size_list)
 
@@ -802,7 +803,7 @@ def shape_only(shape):
     return Shaped(shape)
 
 
-def contract_expression(subscripts, *shapes, **kwargs):
+def contract_expression(subscripts: str, *shapes: Sequence[Tuple[int, ...]], **kwargs: Any):
     """Generate a reusable expression for a given contraction with
     specific shapes, which can, for example, be cached.
 

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from typing import Any, List, Optional, Sequence, Tuple
 
 from . import backends, blas, helpers, parser, paths, sharing
+from .typing import TensorShapeType, PathType
 
 __all__ = ["contract_path", "contract", "format_const_einsum_str", "ContractExpression", "shape_only"]
 
@@ -506,7 +507,7 @@ def contract(*operands, **kwargs):
     return _core_contract(operands, contraction_list, backend=backend, **einsum_kwargs)
 
 
-def infer_backend(x):
+def infer_backend(x: Any) -> str:
     return x.__class__.__module__.split('.')[0]
 
 
@@ -606,7 +607,7 @@ def _core_contract(operands, contraction_list, backend='auto', evaluate_constant
         return operands[0]
 
 
-def format_const_einsum_str(einsum_str, constants):
+def format_const_einsum_str(einsum_str: str, constants: List[int]) -> str:
     """Add brackets to the constant terms in ``einsum_str``. For example:
 
         >>> format_const_einsum_str('ab,bc,cd->ad', [0, 2])
@@ -803,7 +804,7 @@ def shape_only(shape):
     return Shaped(shape)
 
 
-def contract_expression(subscripts: str, *shapes: Sequence[Tuple[int, ...]], **kwargs: Any) -> Any:
+def contract_expression(subscripts: str, *shapes: PathType, **kwargs: Any) -> Any:
     """Generate a reusable expression for a given contraction with
     specific shapes, which can, for example, be cached.
 

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -11,7 +11,7 @@ from . import backends, blas, helpers, parser, paths, sharing
 __all__ = ["contract_path", "contract", "format_const_einsum_str", "ContractExpression", "shape_only"]
 
 
-class PathInfo(object):
+class PathInfo:
     """A printable object to contain information about a contraction path.
 
     Attributes

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -803,7 +803,7 @@ def shape_only(shape):
     return Shaped(shape)
 
 
-def contract_expression(subscripts: str, *shapes: Sequence[Tuple[int, ...]], **kwargs: Any):
+def contract_expression(subscripts: str, *shapes: Sequence[Tuple[int, ...]], **kwargs: Any) -> Any:
     """Generate a reusable expression for a given contraction with
     specific shapes, which can, for example, be cached.
 

--- a/opt_einsum/helpers.py
+++ b/opt_einsum/helpers.py
@@ -50,7 +50,7 @@ def build_views(string: str, dimension_dict: Optional[Dict[str, int]] = None) ->
     return views
 
 
-def compute_size_by_dict(indices: str, idx_dict: Dict[str, int]) -> int:
+def compute_size_by_dict(indices: Collection[str], idx_dict: Dict[str, int]) -> int:
     """
     Computes the product of the elements in indices based on the dictionary
     idx_dict.

--- a/opt_einsum/helpers.py
+++ b/opt_einsum/helpers.py
@@ -3,6 +3,7 @@ Contains helper functions for opt_einsum testing scripts
 """
 
 from collections import OrderedDict
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 import numpy as np
 
@@ -15,13 +16,13 @@ _sizes = np.array([2, 3, 4, 5, 4, 3, 2, 6, 5, 4, 3, 2, 5, 7, 4, 3, 2, 3, 4])
 _default_dim_dict = {c: s for c, s in zip(_valid_chars, _sizes)}
 
 
-def build_views(string, dimension_dict=None):
+def build_views(string: str, dimension_dict: Optional[Dict[str, int]] = None) -> List[np.ndarray]:
     """
     Builds random numpy arrays for testing.
 
     Parameters
     ----------
-    string : list of str
+    string : str
         List of tensor strings to build
     dimension_dict : dictionary
         Dictionary of index _sizes
@@ -33,7 +34,7 @@ def build_views(string, dimension_dict=None):
 
     Examples
     --------
-    >>> view = build_views(['abbc'], {'a': 2, 'b':3, 'c':5})
+    >>> view = build_views('abbc', {'a': 2, 'b':3, 'c':5})
     >>> view[0].shape
     (2, 3, 3, 5)
 
@@ -50,7 +51,7 @@ def build_views(string, dimension_dict=None):
     return views
 
 
-def compute_size_by_dict(indices, idx_dict):
+def compute_size_by_dict(indices: str, idx_dict: Dict[str, int]) -> int:
     """
     Computes the product of the elements in indices based on the dictionary
     idx_dict.
@@ -79,7 +80,8 @@ def compute_size_by_dict(indices, idx_dict):
     return ret
 
 
-def find_contraction(positions, input_sets, output_set):
+def find_contraction(positions: Sequence[int], input_sets: List[Set[str]],
+                     output_set: Set[str]) -> Tuple[Set[str], List[Set[str]], Set[str], Set[str]]:
     """
     Finds the contraction for a given set of input and output sets.
 
@@ -134,7 +136,7 @@ def find_contraction(positions, input_sets, output_set):
     return new_result, remaining, idx_removed, idx_contract
 
 
-def flop_count(idx_contraction, inner, num_terms, size_dictionary):
+def flop_count(idx_contraction: str, inner: bool, num_terms: int, size_dictionary: Dict[str, int]) -> int:
     """
     Computes the number of FLOPS in the contraction.
 
@@ -173,7 +175,14 @@ def flop_count(idx_contraction, inner, num_terms, size_dictionary):
     return overall_size * op_factor
 
 
-def rand_equation(n, reg, n_out=0, d_min=2, d_max=9, seed=None, global_dim=False, return_size_dict=False):
+def rand_equation(n: int,
+                  reg: int,
+                  n_out: int = 0,
+                  d_min: int = 2,
+                  d_max: int = 9,
+                  seed: Optional[int] = None,
+                  global_dim: bool = False,
+                  return_size_dict: bool = False) -> Any:
     """Generate a random contraction and shapes.
 
     Parameters

--- a/opt_einsum/helpers.py
+++ b/opt_einsum/helpers.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union, Colle
 import numpy as np
 
 from .parser import get_symbol
+from .typing import PathType, TensorIndexType
 
 __all__ = ["build_views", "compute_size_by_dict", "find_contraction", "flop_count"]
 
@@ -79,8 +80,9 @@ def compute_size_by_dict(indices: Collection[str], idx_dict: Dict[str, int]) -> 
     return ret
 
 
-def find_contraction(positions: Collection[int], input_sets: List[Set[str]],
-                     output_set: Set[str]) -> Tuple[Set[str], List[Set[str]], Set[str], Set[str]]:
+def find_contraction(
+        positions: Collection[int], input_sets: List[TensorIndexType],
+        output_set: TensorIndexType) -> Tuple[Set[str], List[TensorIndexType], TensorIndexType, TensorIndexType]:
     """
     Finds the contraction for a given set of input and output sets.
 
@@ -174,16 +176,14 @@ def flop_count(idx_contraction: Collection[str], inner: bool, num_terms: int, si
     return overall_size * op_factor
 
 
-def rand_equation(
-    n: int,
-    reg: int,
-    n_out: int = 0,
-    d_min: int = 2,
-    d_max: int = 9,
-    seed: Optional[int] = None,
-    global_dim: bool = False,
-    return_size_dict: bool = False
-) -> Union[Tuple[str, List[Tuple[int, ...]], Dict[str, int]], Tuple[str, List[Tuple[int, ...]]]]:
+def rand_equation(n: int,
+                  reg: int,
+                  n_out: int = 0,
+                  d_min: int = 2,
+                  d_max: int = 9,
+                  seed: Optional[int] = None,
+                  global_dim: bool = False,
+                  return_size_dict: bool = False) -> Union[Tuple[str, PathType, Dict[str, int]], Tuple[str, PathType]]:
     """Generate a random contraction and shapes.
 
     Parameters

--- a/opt_einsum/helpers.py
+++ b/opt_einsum/helpers.py
@@ -2,8 +2,7 @@
 Contains helper functions for opt_einsum testing scripts
 """
 
-from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import numpy as np
 
@@ -175,14 +174,16 @@ def flop_count(idx_contraction: str, inner: bool, num_terms: int, size_dictionar
     return overall_size * op_factor
 
 
-def rand_equation(n: int,
-                  reg: int,
-                  n_out: int = 0,
-                  d_min: int = 2,
-                  d_max: int = 9,
-                  seed: Optional[int] = None,
-                  global_dim: bool = False,
-                  return_size_dict: bool = False) -> Any:
+def rand_equation(
+    n: int,
+    reg: int,
+    n_out: int = 0,
+    d_min: int = 2,
+    d_max: int = 9,
+    seed: Optional[int] = None,
+    global_dim: bool = False,
+    return_size_dict: bool = False
+) -> Union[Tuple[str, List[Tuple[int, ...]], Dict[str, int]], Tuple[str, List[Tuple[int, ...]]]]:
     """Generate a random contraction and shapes.
 
     Parameters
@@ -242,7 +243,7 @@ def rand_equation(n: int,
     inputs = ["" for _ in range(n)]
     output = []
 
-    size_dict = OrderedDict((get_symbol(i), np.random.randint(d_min, d_max + 1)) for i in range(num_inds))
+    size_dict = {get_symbol(i): np.random.randint(d_min, d_max + 1) for i in range(num_inds)}
 
     # generate a list of indices to place either once or twice
     def gen():
@@ -278,7 +279,7 @@ def rand_equation(n: int,
         output += gdim
 
     # randomly transpose the output indices and form equation
-    output = "".join(np.random.permutation(output))
+    output = "".join(np.random.permutation(output))  # type: ignore
     eq = "{}->{}".format(",".join(inputs), output)
 
     # make the shapes
@@ -287,6 +288,6 @@ def rand_equation(n: int,
     ret = (eq, shapes)
 
     if return_size_dict:
-        ret += (size_dict, )
-
-    return ret
+        return ret + (size_dict, )
+    else:
+        return ret

--- a/opt_einsum/helpers.py
+++ b/opt_einsum/helpers.py
@@ -2,7 +2,7 @@
 Contains helper functions for opt_einsum testing scripts
 """
 
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union, Collection
+from typing import Collection, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 

--- a/opt_einsum/helpers.py
+++ b/opt_einsum/helpers.py
@@ -2,7 +2,7 @@
 Contains helper functions for opt_einsum testing scripts
 """
 
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union, Collection
 
 import numpy as np
 
@@ -79,7 +79,7 @@ def compute_size_by_dict(indices: str, idx_dict: Dict[str, int]) -> int:
     return ret
 
 
-def find_contraction(positions: Sequence[int], input_sets: List[Set[str]],
+def find_contraction(positions: Collection[int], input_sets: List[Set[str]],
                      output_set: Set[str]) -> Tuple[Set[str], List[Set[str]], Set[str], Set[str]]:
     """
     Finds the contraction for a given set of input and output sets.
@@ -135,7 +135,7 @@ def find_contraction(positions: Sequence[int], input_sets: List[Set[str]],
     return new_result, remaining, idx_removed, idx_contract
 
 
-def flop_count(idx_contraction: str, inner: bool, num_terms: int, size_dictionary: Dict[str, int]) -> int:
+def flop_count(idx_contraction: Collection[str], inner: bool, num_terms: int, size_dictionary: Dict[str, int]) -> int:
     """
     Computes the number of FLOPS in the contraction.
 

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -6,6 +6,7 @@ A functionally equivalent parser of the numpy.einsum input parser
 
 import itertools
 from collections import OrderedDict
+from typing import Any, Dict, Iterator, List, Tuple
 
 import numpy as np
 
@@ -18,7 +19,7 @@ __all__ = [
 _einsum_symbols_base = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 
-def is_valid_einsum_char(x):
+def is_valid_einsum_char(x: str) -> bool:
     """Check if the character ``x`` is valid for numpy einsum.
 
     Examples
@@ -32,7 +33,7 @@ def is_valid_einsum_char(x):
     return (x in _einsum_symbols_base) or (x in ',->.')
 
 
-def has_valid_einsum_chars_only(einsum_str):
+def has_valid_einsum_chars_only(einsum_str: str) -> bool:
     """Check if ``einsum_str`` contains only valid characters for numpy einsum.
 
     Examples
@@ -46,7 +47,7 @@ def has_valid_einsum_chars_only(einsum_str):
     return all(map(is_valid_einsum_char, einsum_str))
 
 
-def get_symbol(i):
+def get_symbol(i: int) -> str:
     """Get the symbol corresponding to int ``i`` - runs through the usual 52
     letters before resorting to unicode characters, starting at ``chr(192)``.
 
@@ -66,7 +67,7 @@ def get_symbol(i):
     return chr(i + 140)
 
 
-def gen_unused_symbols(used, n):
+def gen_unused_symbols(used: str, n: int) -> Iterator[str]:
     """Generate ``n`` symbols that are not already in ``used``.
 
     Examples
@@ -84,7 +85,7 @@ def gen_unused_symbols(used, n):
         cnt += 1
 
 
-def convert_to_valid_einsum_chars(einsum_str):
+def convert_to_valid_einsum_chars(einsum_str: str) -> str:
     """Convert the str ``einsum_str`` to contain only the alphabetic characters
     valid for numpy einsum. If there are too many symbols, let the backend
     throw an error.
@@ -99,7 +100,7 @@ def convert_to_valid_einsum_chars(einsum_str):
     return "".join(replacer.get(x, x) for x in einsum_str)
 
 
-def alpha_canonicalize(equation):
+def alpha_canonicalize(equation: str) -> str:
     """Alpha convert an equation in an order-independent canonical way.
 
     Examples
@@ -110,7 +111,7 @@ def alpha_canonicalize(equation):
     >>> oe.parser.alpha_canonicalize("Ĥěļļö")
     'abccd'
     """
-    rename = OrderedDict()
+    rename: Dict[str, str] = {}
     for name in equation:
         if name in '.,->':
             continue
@@ -119,7 +120,7 @@ def alpha_canonicalize(equation):
     return ''.join(rename.get(x, x) for x in equation)
 
 
-def find_output_str(subscripts):
+def find_output_str(subscripts: str) -> str:
     """
     Find the output string for the inputs ``subscripts`` under canonical einstein summation rules.
     That is, repeated indices are summed over by default.
@@ -139,7 +140,7 @@ def find_output_str(subscripts):
     return "".join(s for s in sorted(set(tmp_subscripts)) if tmp_subscripts.count(s) == 1)
 
 
-def find_output_shape(inputs, shapes, output):
+def find_output_shape(inputs: List[str], shapes: List[Tuple[int, ...]], output: str) -> Tuple[int, ...]:
     """Find the output shape for given inputs, shapes and output string, taking
     into account broadcasting.
 
@@ -156,7 +157,7 @@ def find_output_shape(inputs, shapes, output):
         max(shape[loc] for shape, loc in zip(shapes, [x.find(c) for x in inputs]) if loc >= 0) for c in output)
 
 
-def possibly_convert_to_numpy(x):
+def possibly_convert_to_numpy(x: Any) -> Any:
     """Convert things without a 'shape' to ndarrays, but leave everything else.
 
     Examples
@@ -187,7 +188,7 @@ def possibly_convert_to_numpy(x):
         return x
 
 
-def convert_subscripts(old_sub, symbol_map):
+def convert_subscripts(old_sub: List[Any], symbol_map: Dict[Any, Any]) -> str:
     """Convert user custom subscripts list to subscript string according to `symbol_map`.
 
     Examples
@@ -244,7 +245,7 @@ def convert_interleaved_input(operands):
     return subscripts, operands
 
 
-def parse_einsum_input(operands):
+def parse_einsum_input(operands: Any) -> Tuple[str, str, List[Any]]:
     """
     A reproduction of einsum c side einsum parsing in python.
 

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -7,6 +7,7 @@ A functionally equivalent parser of the numpy.einsum input parser
 import itertools
 from collections import OrderedDict
 from typing import Any, Dict, Iterator, List, Tuple
+from .typing import TensorShapeType
 
 import numpy as np
 
@@ -140,7 +141,7 @@ def find_output_str(subscripts: str) -> str:
     return "".join(s for s in sorted(set(tmp_subscripts)) if tmp_subscripts.count(s) == 1)
 
 
-def find_output_shape(inputs: List[str], shapes: List[Tuple[int, ...]], output: str) -> Tuple[int, ...]:
+def find_output_shape(inputs: List[str], shapes: List[TensorShapeType], output: str) -> TensorShapeType:
     """Find the output shape for given inputs, shapes and output string, taking
     into account broadcasting.
 
@@ -208,7 +209,7 @@ def convert_subscripts(old_sub: List[Any], symbol_map: Dict[Any, Any]) -> str:
     return new_sub
 
 
-def convert_interleaved_input(operands):
+def convert_interleaved_input(operands: List[Any]) -> Tuple[str, List[Any]]:
     """Convert 'interleaved' input to standard einsum input.
     """
     tmp_operands = list(operands)

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -5,11 +5,11 @@ A functionally equivalent parser of the numpy.einsum input parser
 """
 
 import itertools
-from collections import OrderedDict
 from typing import Any, Dict, Iterator, List, Tuple
-from .typing import TensorShapeType
 
 import numpy as np
+
+from .typing import TensorShapeType
 
 __all__ = [
     "is_valid_einsum_char", "has_valid_einsum_chars_only", "get_symbol", "gen_unused_symbols",

--- a/opt_einsum/path_random.py
+++ b/opt_einsum/path_random.py
@@ -8,21 +8,10 @@ import math
 import numbers
 import time
 from collections import deque
+from random import choices as random_choices
+from random import seed as random_seed
 
 from . import helpers, paths
-
-# random.choices was introduced in python 3.6
-try:
-    from random import choices as random_choices
-    from random import seed as random_seed
-except ImportError:
-    import numpy as np
-
-    def random_choices(population, weights):
-        norm = sum(weights)
-        return np.random.choice(population, p=[w / norm for w in weights], size=1)
-
-    random_seed = np.random.seed
 
 __all__ = ["RandomGreedy", "random_greedy", "random_greedy_128"]
 

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -8,7 +8,7 @@ import itertools
 import operator
 import random
 from collections import Counter, OrderedDict, defaultdict
-from typing import List, Set, FrozenSet, Dict, Tuple, Callable, Optional, Any
+from typing import Any, Callable, Dict, FrozenSet, List, Optional, Tuple
 
 import numpy as np
 

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -8,6 +8,7 @@ import itertools
 import operator
 import random
 from collections import Counter, OrderedDict, defaultdict
+from typing import Dict, FrozenSet, List, Set, Tuple
 
 import numpy as np
 
@@ -19,6 +20,8 @@ __all__ = [
 ]
 
 _UNLIMITED_MEM = {-1, None, float('inf')}
+
+PathType = List[Tuple[int, ...]]
 
 
 class PathOptimizer(object):
@@ -60,7 +63,7 @@ class PathOptimizer(object):
         raise NotImplementedError
 
 
-def ssa_to_linear(ssa_path):
+def ssa_to_linear(ssa_path: PathType) -> PathType:
     """
     Convert a path with static single assignment ids to a path with recycled
     linear ids. For example::
@@ -77,7 +80,7 @@ def ssa_to_linear(ssa_path):
     return path
 
 
-def linear_to_ssa(path):
+def linear_to_ssa(path: PathType) -> PathType:
     """
     Convert a path with recycled linear ids to a path with static single
     assignment ids. For example::
@@ -97,7 +100,8 @@ def linear_to_ssa(path):
     return ssa_path
 
 
-def calc_k12_flops(inputs, output, remaining, i, j, size_dict):
+def calc_k12_flops(inputs: Tuple[FrozenSet[str]], output: FrozenSet[str], remaining: FrozenSet[int], i: t, j: int,
+                   size_dict: Dict[str, int]) -> FrozenSet[int]:
     """
     Calculate the resulting indices and flops for a potential pairwise
     contraction - used in the recursive (optimal/branch) algorithms.

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -1107,7 +1107,10 @@ for i in range(9, 15):
     _AUTO_CHOICES[i] = branch_1
 
 
-def auto(inputs, output, size_dict, memory_limit=None):
+def auto(inputs: List[TensorIndexType],
+         output: TensorIndexType,
+         size_dict: Dict[str, int],
+         memory_limit: Optional[int] = None) -> PathType:
     """Finds the contraction path by automatically choosing the method based on
     how many input arguments there are.
     """
@@ -1122,7 +1125,10 @@ for i in range(6, 17):
     _AUTO_HQ_CHOICES[i] = dynamic_programming
 
 
-def auto_hq(inputs, output, size_dict, memory_limit=None):
+def auto_hq(inputs: List[TensorIndexType],
+            output: TensorIndexType,
+            size_dict: Dict[str, int],
+            memory_limit: Optional[int] = None) -> PathType:
     """Finds the contraction path by automatically choosing the method based on
     how many input arguments there are, but targeting a more generous
     amount of search time than ``'auto'``.
@@ -1133,7 +1139,8 @@ def auto_hq(inputs, output, size_dict, memory_limit=None):
     return _AUTO_HQ_CHOICES.get(N, random_greedy_128)(inputs, output, size_dict, memory_limit)
 
 
-_PATH_OPTIONS = {
+PathSearchFunctionType = Callable[[List[TensorIndexType], TensorIndexType, Dict[str, int], Optional[int]], PathType]
+_PATH_OPTIONS: Dict[str, PathSearchFunctionType] = {
     'auto': auto,
     'auto-hq': auto_hq,
     'optimal': optimal,
@@ -1148,7 +1155,7 @@ _PATH_OPTIONS = {
 }
 
 
-def register_path_fn(name, fn):
+def register_path_fn(name: str, fn: PathSearchFunctionType) -> None:
     """Add path finding function ``fn`` as an option with ``name``.
     """
     if name in _PATH_OPTIONS:
@@ -1157,9 +1164,10 @@ def register_path_fn(name, fn):
     _PATH_OPTIONS[name.lower()] = fn
 
 
-def get_path_fn(path_type):
+def get_path_fn(path_type: str) -> PathSearchFunctionType:
     """Get the correct path finding function from str ``path_type``.
     """
+    path_type = path_type.lower()
     if path_type not in _PATH_OPTIONS:
         raise KeyError("Path optimizer '{}' not found, valid options are {}.".format(
             path_type, set(_PATH_OPTIONS.keys())))

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -5,8 +5,8 @@ Contains the path technology behind opt_einsum in addition to several path helpe
 import functools
 import heapq
 import itertools
-import random
 import operator
+import random
 from collections import Counter, OrderedDict, defaultdict
 
 import numpy as np

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -71,7 +71,7 @@ def ssa_to_linear(ssa_path: PathType) -> PathType:
         >>> ssa_to_linear([(0, 3), (2, 4), (1, 5)])
         [(0, 3), (1, 2), (0, 1)]
     """
-    ids = np.arange(1 + max(map(max, ssa_path)), dtype=np.int32)
+    ids = np.arange(1 + max(map(max, ssa_path)), dtype=np.int32)  # type: ignore
     path = []
     for ssa_ids in ssa_path:
         path.append(tuple(int(ids[ssa_id]) for ssa_id in ssa_ids))
@@ -100,8 +100,8 @@ def linear_to_ssa(path: PathType) -> PathType:
     return ssa_path
 
 
-def calc_k12_flops(inputs: Tuple[FrozenSet[str]], output: FrozenSet[str], remaining: FrozenSet[int], i: t, j: int,
-                   size_dict: Dict[str, int]) -> FrozenSet[int]:
+def calc_k12_flops(inputs: Tuple[FrozenSet[str]], output: FrozenSet[str], remaining: FrozenSet[int], i: int, j: int,
+                   size_dict: Dict[str, int]) -> Tuple[FrozenSet[str], int]:
     """
     Calculate the resulting indices and flops for a potential pairwise
     contraction - used in the recursive (optimal/branch) algorithms.
@@ -137,7 +137,7 @@ def calc_k12_flops(inputs: Tuple[FrozenSet[str]], output: FrozenSet[str], remain
     keep = frozenset.union(output, *map(inputs.__getitem__, remaining - {i, j}))
 
     k12 = either & keep
-    cost = helpers.flop_count(either, shared - keep, 2, size_dict)
+    cost = helpers.flop_count(either, bool(shared - keep), 2, size_dict)
 
     return k12, cost
 

--- a/opt_einsum/sharing.py
+++ b/opt_einsum/sharing.py
@@ -20,7 +20,7 @@ __all__ = [
 _SHARING_STACK = defaultdict(list)
 
 
-def currently_sharing():
+def currently_sharing() -> bool:
     """Check if we are currently sharing a cache -- thread specific.
     """
     return threading.get_ident() in _SHARING_STACK

--- a/opt_einsum/sharing.py
+++ b/opt_einsum/sharing.py
@@ -9,6 +9,7 @@ import functools
 import numbers
 import threading
 from collections import Counter, defaultdict
+from typing import Any
 
 from .parser import alpha_canonicalize, parse_einsum_input
 
@@ -17,7 +18,7 @@ __all__ = [
     "einsum_cache_wrap", "to_backend_cache_wrap"
 ]
 
-_SHARING_STACK = defaultdict(list)
+_SHARING_STACK: Any = defaultdict(list)
 
 
 def currently_sharing() -> bool:

--- a/opt_einsum/tests/test_backends.py
+++ b/opt_einsum/tests/test_backends.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from opt_einsum import (backends, contract, contract_expression, helpers, sharing)
+from opt_einsum import backends, contract, contract_expression, helpers, sharing
 from opt_einsum.contract import Shaped, infer_backend, parse_backend
 
 try:
@@ -12,6 +12,7 @@ except ImportError:
 
 try:
     import tensorflow as tf
+
     # needed so tensorflow doesn't allocate all gpu mem
     try:
         from tensorflow import ConfigProto

--- a/opt_einsum/tests/test_sharing.py
+++ b/opt_einsum/tests/test_sharing.py
@@ -15,13 +15,13 @@ try:
     import cupy
     cupy_if_found = 'cupy'
 except ImportError:
-    cupy_if_found = pytest.param('cupy', marks=[pytest.mark.skip(reason="CuPy not installed.")])
+    cupy_if_found = pytest.param('cupy', marks=[pytest.mark.skip(reason="CuPy not installed.")])  # type: ignore
 
 try:
     import torch
     torch_if_found = 'torch'
 except ImportError:
-    torch_if_found = pytest.param('torch', marks=[pytest.mark.skip(reason="PyTorch not installed.")])
+    torch_if_found = pytest.param('torch', marks=[pytest.mark.skip(reason="PyTorch not installed.")])  # type: ignore
 
 backends = ['numpy', torch_if_found, cupy_if_found]
 equations = [

--- a/opt_einsum/tests/test_sharing.py
+++ b/opt_einsum/tests/test_sharing.py
@@ -5,11 +5,11 @@ from collections import Counter
 import numpy as np
 import pytest
 
-from opt_einsum import (contract, contract_expression, contract_path, get_symbol, helpers, shared_intermediates)
+from opt_einsum import contract, contract_expression, contract_path, get_symbol, helpers, shared_intermediates
 from opt_einsum.backends import to_cupy, to_torch
 from opt_einsum.contract import _einsum
 from opt_einsum.parser import parse_einsum_input
-from opt_einsum.sharing import (count_cached_ops, currently_sharing, get_sharing_cache)
+from opt_einsum.sharing import count_cached_ops, currently_sharing, get_sharing_cache
 
 try:
     import cupy

--- a/opt_einsum/typing.py
+++ b/opt_einsum/typing.py
@@ -2,8 +2,8 @@
 Types used in the opt_einsum package
 """
 
-from typing import List, Tuple, Set
+from typing import List, Tuple, Set, Collection
 
-PathType = List[Tuple[int, ...]]
+PathType = Collection[Tuple[int, ...]]
 TensorIndexType = Set[str]
 TensorShapeType = Tuple[int, ...]

--- a/opt_einsum/typing.py
+++ b/opt_einsum/typing.py
@@ -1,0 +1,9 @@
+"""
+Types used in the opt_einsum package
+"""
+
+from typing import List, Tuple, Set
+
+PathType = List[Tuple[int, ...]]
+TensorIndexType = Set[str]
+TensorShapeType = Tuple[int, ...]

--- a/opt_einsum/typing.py
+++ b/opt_einsum/typing.py
@@ -2,7 +2,7 @@
 Types used in the opt_einsum package
 """
 
-from typing import List, Tuple, Set, Collection
+from typing import Collection, Set, Tuple
 
 PathType = Collection[Tuple[int, ...]]
 TensorIndexType = Set[str]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,12 +40,42 @@ versionfile_build = opt_einsum/_version.py
 tag_prefix = ''
 
 [mypy]
-plugins = numpy.typing.mypy_plugin
+#plugins = numpy.typing.mypy_plugin
 
 follow_imports = normal
 strict_optional = True
 warn_redundant_casts = True
-no_implicit_reexport = True
+# no_implicit_reexport = True
 warn_unused_configs = True
 disallow_incomplete_defs = True
 warn_unused_ignores = True
+
+[mypy-opt_einsum.tests.*]
+ignore_missing_imports = True
+
+[mypy-opt_einsum._version]
+ignore_errors = True
+
+[mypy-autograd.*]
+ignore_missing_imports = True
+
+[mypy-cupy.*]
+ignore_missing_imports = True
+
+[mypy-tensorflow.*]
+ignore_missing_imports = True
+
+[mypy-tf.*]
+ignore_missing_imports = True
+
+[mypy-theano.*]
+ignore_missing_imports = True
+
+[mypy-torch.*]
+ignore_missing_imports = True
+
+[mypy-jax.*]
+ignore_missing_imports = True
+
+[mypy-xla.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,13 @@ omit =
     opt_einsum/_version.py
     versioneer.py
 
+[tool:isort]
+line_length=120
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+multi_line_output=3
+
 
 [yapf]
 # YAPF, in .style.yapf files this shows up as "[style]" header
@@ -31,3 +38,14 @@ style = pep440
 versionfile_source = opt_einsum/_version.py
 versionfile_build = opt_einsum/_version.py
 tag_prefix = ''
+
+[mypy]
+plugins = numpy.typing.mypy_plugin
+
+follow_imports = normal
+strict_optional = True
+warn_redundant_casts = True
+no_implicit_reexport = True
+warn_unused_configs = True
+disallow_incomplete_defs = True
+warn_unused_ignores = True

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
         url="https://github.com/dgasmith/opt_einsum",
         license='MIT',
         packages=setuptools.find_packages(),
-        python_requires='>=3.5',
+        python_requires='>=3.6',
         install_requires=[
             'numpy>=1.7',
         ],


### PR DESCRIPTION
## Description
Bumps minimum python version to 3.6 according to [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html). We should bump to 3.7, but many libraries (torch!) are relatively slow to deprecate python versions, this seems like a reasonable compromise which allows us to type the library.

## Questions
 - [ ] Considering the range of inputs for contract/contract path, I'm leaning towards putting an Any on them for now. Any objections?
 - [ ] ArrayType is a Union which could *become* a `np.ndarray` meaning all interfaces should use `np.asanarray` upon call to convert to `np.ndarray` types. It doesn't seem `asanyarray` is typed yet in the docs. Considering leaving these as Any as well since we tend to pass the base type through (called Tensor classes). Any guidance here?

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Bump Python to >= 3.6
  - [x] Add Python typing to the library
  - [x] Add a MyPy merge gate

## Status
- [ ] Ready to go