### PR TITLE
Prevents double contraction of floats in dynamic path, fixes #172

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         python-version: [3.6, 3.7]
         environment: ["min-deps", "full", "min-ver"]
+        exclude:
+         - python-version: 3.6
+           environment: "full"
 
     runs-on: ubuntu-latest
 

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -1016,7 +1016,7 @@ class DynamicProgramming(PathOptimizer):
                 cost_cap = self.cost_cap
             # set the factor to increase the cost by each iteration (ensure > 1)
             if len(subgraph_inds) == 0:
-                cost_increment = 1
+                cost_increment = 2
             else:
                 cost_increment = max(min(map(size_dict.__getitem__, subgraph_inds)), 2)
 

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -861,7 +861,7 @@ def _dp_parse_out_single_term_ops(inputs, all_inds, ind_counts):
     inputs_parsed, inputs_done, inputs_contractions = [], [], []
     for j, i in enumerate(inputs):
         i_reduced = i - i_single
-        if not i_reduced:
+        if (not i_reduced) and (len(i) > 0):
             # input reduced to scalar already - remove
             inputs_done.append((j, ))
         else:
@@ -1015,7 +1015,10 @@ class DynamicProgramming(PathOptimizer):
             else:
                 cost_cap = self.cost_cap
             # set the factor to increase the cost by each iteration (ensure > 1)
-            cost_increment = max(min(map(size_dict.__getitem__, subgraph_inds)), 2)
+            if len(subgraph_inds) == 0:
+                cost_increment = 1
+            else:
+                cost_increment = max(min(map(size_dict.__getitem__, subgraph_inds)), 2)
 
             while len(x[-1]) == 0:
                 for n in range(2, len(x[1]) + 1):

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -51,6 +51,17 @@ path_edge_tests = [
     ['dp', 'dcc,fce,ea,dbf->ab', ((1, 2), (0, 2), (0, 1))],
 ]
 
+# note that these tests have no unique solution due to the chosen dimensions
+path_scalar_tests = [
+    [
+        'a,->a',
+        1,
+    ],
+    ['ab,->ab', 1],
+    [',a,->a', 2],
+    [',,a,->a', 3],
+]
+
 
 def check_path(test_output, benchmark, bypass=False):
     if not isinstance(test_output, list):
@@ -170,6 +181,17 @@ def test_path_edge_cases(alg, expression, order):
     # Test tiny memory limit
     path_ret = oe.contract_path(expression, *views, optimize=alg)
     assert check_path(path_ret[0], order)
+
+
+@pytest.mark.parametrize("expression,order", path_scalar_tests)
+@pytest.mark.parametrize("alg", oe.paths._PATH_OPTIONS)
+def test_path_scalar_cases(alg, expression, order):
+    views = oe.helpers.build_views(expression)
+
+    # Test tiny memory limit
+    path_ret = oe.contract_path(expression, *views, optimize=alg)
+    # print(path_ret[0])
+    assert len(path_ret[0]) == order
 
 
 def test_optimal_edge_cases():


### PR DESCRIPTION
## Description
The dynamic path will find disconnected subgraphs such as `aa, bc->bc` and automatically contract `aa->` on the fly as a pre optimization measure; however, the contraction `,bc->bc` (float, matrix -> matrix) was not considered and the float is first pre contracted `->` (a no-op). This PR prevents these no-ops to simplify the output path.

## Status
- [x] Ready to go