### PR TITLE
more custom dp scores for faster contractions

### DIFF
--- a/docs/paths/dp_path.md
+++ b/docs/paths/dp_path.md
@@ -70,3 +70,23 @@ oe.contract(eq, *arrays, optimize=optimizer)
 !!! warning
     Note that searching outer products will most likely drastically slow down
     the optimizer on all but the smallest examples.
+
+
+The values that `minimize` can take are:
+
+- `'flops'`: minimize the total number of scalar operations.
+- `'size'`: minimize the size of the largest intermediate.
+- `'write'`: minimize the combined size of all intermediate tensors -
+   approximately speaking the amount of memory that will be written. This is
+   relevant if you were to automatically differentiate through the
+   contraction, which naively would require storing all intermediates.
+- `'combo'` - minimize `flops + alpha * write` summed over intermediates, a
+  default ratio of `alpha=64` is used, or it can be customized with
+  `f'combo-{alpha}'`.
+- `'limit'` - minimize `max(flops, alpha * write)` summed over intermediates, a
+  default ratio of `alpha=64` is used, or it can be customized with `f'limit-{alpha}'`.
+
+The last two take into account the fact that real contraction performance can
+be bound by memory speed, and so favor paths with higher arithmetic
+intensity. The default value of `alpha=64` is reasonable for both typical
+CPUs and GPUs.

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -60,10 +60,7 @@ class PathOptimizer:
     """
 
     def _check_args_against_first_call(
-        self,
-        inputs: List[ArrayIndexType],
-        output: ArrayIndexType,
-        size_dict: Dict[str, int],
+        self, inputs: List[ArrayIndexType], output: ArrayIndexType, size_dict: Dict[str, int],
     ) -> None:
         """Utility that stateful optimizers can use to ensure they are not
         called with different contractions across separate runs.
@@ -169,10 +166,7 @@ def calc_k12_flops(
 
 
 def _compute_oversize_flops(
-    inputs: Tuple[FrozenSet[str]],
-    remaining: List[ArrayIndexType],
-    output: ArrayIndexType,
-    size_dict: Dict[str, int],
+    inputs: Tuple[FrozenSet[str]], remaining: List[ArrayIndexType], output: ArrayIndexType, size_dict: Dict[str, int],
 ) -> int:
     """
     Compute the flop count for a contraction of all remaining arguments. This
@@ -185,10 +179,7 @@ def _compute_oversize_flops(
 
 
 def optimal(
-    inputs: List[ArrayIndexType],
-    output: ArrayIndexType,
-    size_dict: Dict[str, int],
-    memory_limit: Optional[int] = None,
+    inputs: List[ArrayIndexType], output: ArrayIndexType, size_dict: Dict[str, int], memory_limit: Optional[int] = None,
 ) -> PathType:
     """
     Computes all possible pair contractions in a depth-first recursive manner,
@@ -346,11 +337,7 @@ class BranchBound(PathOptimizer):
     """
 
     def __init__(
-        self,
-        nbranch=None,
-        cutoff_flops_factor=4,
-        minimize="flops",
-        cost_fn="memory-removed",
+        self, nbranch=None, cutoff_flops_factor=4, minimize="flops", cost_fn="memory-removed",
     ):
         self.nbranch = nbranch
         self.cutoff_flops_factor = cutoff_flops_factor
@@ -528,14 +515,7 @@ def _get_candidate(
     two = k1 & k2
     one = either - two
     k12 = (either & output) | (two & dim_ref_counts[3]) | (one & dim_ref_counts[2])
-    cost = cost_fn(
-        compute_size_by_dict(k12, sizes),
-        footprints[k1],
-        footprints[k2],
-        k12,
-        k1,
-        k2,
-    )
+    cost = cost_fn(compute_size_by_dict(k12, sizes), footprints[k1], footprints[k2], k12, k1, k2,)
     id1 = remaining[k1]
     id2 = remaining[k2]
     if id1 > id2:
@@ -566,9 +546,7 @@ def _push_candidate(
 
 
 def _update_ref_counts(
-    dim_to_keys: Dict[str, Set[ArrayIndexType]],
-    dim_ref_counts: Dict[int, Set[str]],
-    dims: ArrayIndexType,
+    dim_to_keys: Dict[str, Set[ArrayIndexType]], dim_ref_counts: Dict[int, Set[str]], dims: ArrayIndexType,
 ) -> None:
     for dim in dims:
         count = len(dim_to_keys[dim])
@@ -659,16 +637,7 @@ def ssa_greedy_optimize(
         for i, k1 in enumerate(dim_keys_list[:-1]):
             k2s_guess = dim_keys_list[1 + i :]
             _push_candidate(
-                output,
-                sizes,
-                remaining,
-                footprints,
-                dim_ref_counts,
-                k1,
-                k2s_guess,
-                queue,
-                push_all,
-                cost_fn,
+                output, sizes, remaining, footprints, dim_ref_counts, k1, k2s_guess, queue, push_all, cost_fn,
             )
 
     # Greedily contract pairs of tensors.
@@ -701,22 +670,11 @@ def ssa_greedy_optimize(
         k2s.discard(k1)
         if k2s:
             _push_candidate(
-                output,
-                sizes,
-                remaining,
-                footprints,
-                dim_ref_counts,
-                k1,
-                list(k2s),
-                queue,
-                push_all,
-                cost_fn,
+                output, sizes, remaining, footprints, dim_ref_counts, k1, list(k2s), queue, push_all, cost_fn,
             )
 
     # Greedily compute pairwise outer products.
-    final_queue = [
-        (compute_size_by_dict(key & output, sizes), ssa_id, key) for key, ssa_id in remaining.items()
-    ]
+    final_queue = [(compute_size_by_dict(key & output, sizes), ssa_id, key) for key, ssa_id in remaining.items()]
     heapq.heapify(final_queue)
     _, ssa_id1, k1 = heapq.heappop(final_queue)
     while final_queue:
@@ -980,8 +938,23 @@ def _dp_compare_size(
                 xn[s] = (i, cost, (contract1, contract2))
 
 
-def _dp_compare_write(cost1, cost2, i1_union_i2, size_dict, cost_cap, s1, s2, xn, g, all_tensors, inputs,
-                      i1_cut_i2_wo_output, memory_limit, cntrct1, cntrct2):
+def _dp_compare_write(
+    cost1,
+    cost2,
+    i1_union_i2,
+    size_dict,
+    cost_cap,
+    s1,
+    s2,
+    xn,
+    g,
+    all_tensors,
+    inputs,
+    i1_cut_i2_wo_output,
+    memory_limit,
+    cntrct1,
+    cntrct2,
+):
     """Like ``_dp_compare_flops`` but sieves the potential contraction based
     on the total size of memory created, rather than the number of
     operations, and so calculates that first.
@@ -999,9 +972,25 @@ def _dp_compare_write(cost1, cost2, i1_union_i2, size_dict, cost_cap, s1, s2, xn
 DEFAULT_COMBO_FACTOR = 64
 
 
-def _dp_compare_combo(cost1, cost2, i1_union_i2, size_dict, cost_cap, s1, s2, xn, g, all_tensors, inputs,
-                      i1_cut_i2_wo_output, memory_limit, cntrct1, cntrct2,
-                      factor=DEFAULT_COMBO_FACTOR, combine=sum):
+def _dp_compare_combo(
+    cost1,
+    cost2,
+    i1_union_i2,
+    size_dict,
+    cost_cap,
+    s1,
+    s2,
+    xn,
+    g,
+    all_tensors,
+    inputs,
+    i1_cut_i2_wo_output,
+    memory_limit,
+    cntrct1,
+    cntrct2,
+    factor=DEFAULT_COMBO_FACTOR,
+    combine=sum,
+):
     """Like ``_dp_compare_flops`` but sieves the potential contraction based
     on some combination of both the flops and size,
     """
@@ -1024,25 +1013,25 @@ def _parse_minimize(minimize):
     """This works out what local scoring function to use for the dp algorithm
     as well as a `naive_scale` to account for the memory_limit checks.
     """
-    if minimize == 'flops':
+    if minimize == "flops":
         return _dp_compare_flops, 1
-    if minimize == 'size':
+    if minimize == "size":
         return _dp_compare_size, 1
-    if minimize == 'write':
+    if minimize == "write":
         return _dp_compare_write, 1
 
     # default to naive_scale=inf as otherwise memory_limit check can cause problems
 
     if callable(minimize):
-        return minimize, float('inf')
+        return minimize, float("inf")
 
     # parse out a customized value for the combination factor
     minimize, factor = minimize_finder.fullmatch(minimize).groups()
     factor = float(factor) if factor else DEFAULT_COMBO_FACTOR
-    if minimize == 'combo':
-        return functools.partial(_dp_compare_combo, factor=factor, combine=sum), float('inf')
-    if minimize == 'limit':
-        return functools.partial(_dp_compare_combo, factor=factor, combine=max), float('inf')
+    if minimize == "combo":
+        return functools.partial(_dp_compare_combo, factor=factor, combine=sum), float("inf")
+    if minimize == "limit":
+        return functools.partial(_dp_compare_combo, factor=factor, combine=max), float("inf")
 
     raise ValueError(f"Couldn't parse `minimize` value: {minimize}.")
 
@@ -1287,10 +1276,7 @@ class DynamicProgramming(PathOptimizer):
         # outer products should be performed pairwise (to use BLAS functions)
         subgraph_contractions = [
             subgraph_contractions[j]
-            for j in sorted(
-                range(len(subgraph_contractions_size)),
-                key=subgraph_contractions_size.__getitem__,
-            )
+            for j in sorted(range(len(subgraph_contractions_size)), key=subgraph_contractions_size.__getitem__,)
         ]
 
         # build the final contraction tree
@@ -1321,10 +1307,7 @@ for i in range(9, 15):
 
 
 def auto(
-    inputs: List[ArrayIndexType],
-    output: ArrayIndexType,
-    size_dict: Dict[str, int],
-    memory_limit: Optional[int] = None,
+    inputs: List[ArrayIndexType], output: ArrayIndexType, size_dict: Dict[str, int], memory_limit: Optional[int] = None,
 ) -> PathType:
     """Finds the contraction path by automatically choosing the method based on
     how many input arguments there are.
@@ -1341,10 +1324,7 @@ for i in range(6, 17):
 
 
 def auto_hq(
-    inputs: List[ArrayIndexType],
-    output: ArrayIndexType,
-    size_dict: Dict[str, int],
-    memory_limit: Optional[int] = None,
+    inputs: List[ArrayIndexType], output: ArrayIndexType, size_dict: Dict[str, int], memory_limit: Optional[int] = None,
 ) -> PathType:
     """Finds the contraction path by automatically choosing the method based on
     how many input arguments there are, but targeting a more generous

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -1028,8 +1028,8 @@ def _dp_compare_combo(
     memory_limit: Optional[int],
     contract1: Union[int, Tuple[int]],
     contract2: Union[int, Tuple[int]],
-    factor: Union[int, float]=DEFAULT_COMBO_FACTOR,
-    combine: Callable=sum,
+    factor: Union[int, float] = DEFAULT_COMBO_FACTOR,
+    combine: Callable = sum,
 ):
     """Like ``_dp_compare_flops`` but sieves the potential contraction based
     on some combination of both the flops and size,
@@ -1138,7 +1138,7 @@ class DynamicProgramming(PathOptimizer):
         - 'write' - minimize the size of all intermediate tensors
         - 'combo' - minimize `flops + alpha * write` summed over intermediates, a default ratio of alpha=64
           is used, or it can be customized with `f'combo-{alpha}'`
-        - 'limit' - minimize `max(flops, alpha * write)` summed over intermediate, a default ratio of alpha=64
+        - 'limit' - minimize `max(flops, alpha * write)` summed over intermediates, a default ratio of alpha=64
           is used, or it can be customized with `f'limit-{alpha}'`
         - callable - a custom local cost function
 

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -60,7 +60,10 @@ class PathOptimizer:
     """
 
     def _check_args_against_first_call(
-        self, inputs: List[ArrayIndexType], output: ArrayIndexType, size_dict: Dict[str, int],
+        self,
+        inputs: List[ArrayIndexType],
+        output: ArrayIndexType,
+        size_dict: Dict[str, int],
     ) -> None:
         """Utility that stateful optimizers can use to ensure they are not
         called with different contractions across separate runs.
@@ -166,7 +169,10 @@ def calc_k12_flops(
 
 
 def _compute_oversize_flops(
-    inputs: Tuple[FrozenSet[str]], remaining: List[ArrayIndexType], output: ArrayIndexType, size_dict: Dict[str, int],
+    inputs: Tuple[FrozenSet[str]],
+    remaining: List[ArrayIndexType],
+    output: ArrayIndexType,
+    size_dict: Dict[str, int],
 ) -> int:
     """
     Compute the flop count for a contraction of all remaining arguments. This
@@ -179,7 +185,10 @@ def _compute_oversize_flops(
 
 
 def optimal(
-    inputs: List[ArrayIndexType], output: ArrayIndexType, size_dict: Dict[str, int], memory_limit: Optional[int] = None,
+    inputs: List[ArrayIndexType],
+    output: ArrayIndexType,
+    size_dict: Dict[str, int],
+    memory_limit: Optional[int] = None,
 ) -> PathType:
     """
     Computes all possible pair contractions in a depth-first recursive manner,
@@ -337,7 +346,11 @@ class BranchBound(PathOptimizer):
     """
 
     def __init__(
-        self, nbranch=None, cutoff_flops_factor=4, minimize="flops", cost_fn="memory-removed",
+        self,
+        nbranch=None,
+        cutoff_flops_factor=4,
+        minimize="flops",
+        cost_fn="memory-removed",
     ):
         self.nbranch = nbranch
         self.cutoff_flops_factor = cutoff_flops_factor
@@ -515,7 +528,14 @@ def _get_candidate(
     two = k1 & k2
     one = either - two
     k12 = (either & output) | (two & dim_ref_counts[3]) | (one & dim_ref_counts[2])
-    cost = cost_fn(compute_size_by_dict(k12, sizes), footprints[k1], footprints[k2], k12, k1, k2,)
+    cost = cost_fn(
+        compute_size_by_dict(k12, sizes),
+        footprints[k1],
+        footprints[k2],
+        k12,
+        k1,
+        k2,
+    )
     id1 = remaining[k1]
     id2 = remaining[k2]
     if id1 > id2:
@@ -546,7 +566,9 @@ def _push_candidate(
 
 
 def _update_ref_counts(
-    dim_to_keys: Dict[str, Set[ArrayIndexType]], dim_ref_counts: Dict[int, Set[str]], dims: ArrayIndexType,
+    dim_to_keys: Dict[str, Set[ArrayIndexType]],
+    dim_ref_counts: Dict[int, Set[str]],
+    dims: ArrayIndexType,
 ) -> None:
     for dim in dims:
         count = len(dim_to_keys[dim])
@@ -637,7 +659,16 @@ def ssa_greedy_optimize(
         for i, k1 in enumerate(dim_keys_list[:-1]):
             k2s_guess = dim_keys_list[1 + i :]
             _push_candidate(
-                output, sizes, remaining, footprints, dim_ref_counts, k1, k2s_guess, queue, push_all, cost_fn,
+                output,
+                sizes,
+                remaining,
+                footprints,
+                dim_ref_counts,
+                k1,
+                k2s_guess,
+                queue,
+                push_all,
+                cost_fn,
             )
 
     # Greedily contract pairs of tensors.
@@ -670,7 +701,16 @@ def ssa_greedy_optimize(
         k2s.discard(k1)
         if k2s:
             _push_candidate(
-                output, sizes, remaining, footprints, dim_ref_counts, k1, list(k2s), queue, push_all, cost_fn,
+                output,
+                sizes,
+                remaining,
+                footprints,
+                dim_ref_counts,
+                k1,
+                list(k2s),
+                queue,
+                push_all,
+                cost_fn,
             )
 
     # Greedily compute pairwise outer products.
@@ -1276,7 +1316,10 @@ class DynamicProgramming(PathOptimizer):
         # outer products should be performed pairwise (to use BLAS functions)
         subgraph_contractions = [
             subgraph_contractions[j]
-            for j in sorted(range(len(subgraph_contractions_size)), key=subgraph_contractions_size.__getitem__,)
+            for j in sorted(
+                range(len(subgraph_contractions_size)),
+                key=subgraph_contractions_size.__getitem__,
+            )
         ]
 
         # build the final contraction tree
@@ -1307,7 +1350,10 @@ for i in range(9, 15):
 
 
 def auto(
-    inputs: List[ArrayIndexType], output: ArrayIndexType, size_dict: Dict[str, int], memory_limit: Optional[int] = None,
+    inputs: List[ArrayIndexType],
+    output: ArrayIndexType,
+    size_dict: Dict[str, int],
+    memory_limit: Optional[int] = None,
 ) -> PathType:
     """Finds the contraction path by automatically choosing the method based on
     how many input arguments there are.
@@ -1324,7 +1370,10 @@ for i in range(6, 17):
 
 
 def auto_hq(
-    inputs: List[ArrayIndexType], output: ArrayIndexType, size_dict: Dict[str, int], memory_limit: Optional[int] = None,
+    inputs: List[ArrayIndexType],
+    output: ArrayIndexType,
+    size_dict: Dict[str, int],
+    memory_limit: Optional[int] = None,
 ) -> PathType:
     """Finds the contraction path by automatically choosing the method based on
     how many input arguments there are, but targeting a more generous

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -1069,8 +1069,8 @@ def _parse_minimize(minimize: Union[str, Callable]) -> Tuple[Callable, Union[int
     if match is None:
         raise ValueError(f"Couldn't parse `minimize` value: {minimize}.")
 
-    minimize, factor = match.groups()
-    factor = float(factor) if factor else DEFAULT_COMBO_FACTOR
+    minimize, custom_factor = match.groups()
+    factor = float(custom_factor) if custom_factor else DEFAULT_COMBO_FACTOR
     if minimize == "combo":
         return functools.partial(_dp_compare_combo, factor=factor, combine=sum), float("inf")
     elif minimize == "limit":

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -994,7 +994,7 @@ def _dp_compare_write(
     memory_limit: Optional[int],
     contract1: Union[int, Tuple[int]],
     contract2: Union[int, Tuple[int]],
-):
+) -> None:
     """Like ``_dp_compare_flops`` but sieves the potential contraction based
     on the total size of memory created, rather than the number of
     operations, and so calculates that first.
@@ -1030,7 +1030,7 @@ def _dp_compare_combo(
     contract2: Union[int, Tuple[int]],
     factor: Union[int, float] = DEFAULT_COMBO_FACTOR,
     combine: Callable = sum,
-):
+) -> None:
     """Like ``_dp_compare_flops`` but sieves the potential contraction based
     on some combination of both the flops and size,
     """
@@ -1049,7 +1049,7 @@ minimize_finder = re.compile(r"(flops|size|write|combo|limit)-*(\d*)")
 
 
 @functools.lru_cache(128)
-def _parse_minimize(minimize: Union[str, Callable]):
+def _parse_minimize(minimize: Union[str, Callable]) -> Tuple[Callable, Union[int, float]]:
     """This works out what local scoring function to use for the dp algorithm
     as well as a `naive_scale` to account for the memory_limit checks.
     """
@@ -1065,7 +1065,11 @@ def _parse_minimize(minimize: Union[str, Callable]):
         return minimize, float("inf")
 
     # parse out a customized value for the combination factor
-    minimize, factor = minimize_finder.fullmatch(minimize).groups()
+    match = minimize_finder.fullmatch(minimize)
+    if match is None:
+        raise ValueError(f"Couldn't parse `minimize` value: {minimize}.")
+
+    minimize, factor = match.groups()
     factor = float(factor) if factor else DEFAULT_COMBO_FACTOR
     if minimize == "combo":
         return functools.partial(_dp_compare_combo, factor=factor, combine=sum), float("inf")

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -12,8 +12,16 @@ import pytest
 import opt_einsum as oe
 
 explicit_path_tests = {
-    "GEMM1": ([set("abd"), set("ac"), set("bdc")], set(""), {"a": 1, "b": 2, "c": 3, "d": 4},),
-    "Inner1": ([set("abcd"), set("abc"), set("bc")], set(""), {"a": 5, "b": 2, "c": 3, "d": 4},),
+    "GEMM1": (
+        [set("abd"), set("ac"), set("bdc")],
+        set(""),
+        {"a": 1, "b": 2, "c": 3, "d": 4},
+    ),
+    "Inner1": (
+        [set("abcd"), set("abc"), set("bc")],
+        set(""),
+        {"a": 5, "b": 2, "c": 3, "d": 4},
+    ),
 }
 
 # note that these tests have no unique solution due to the chosen dimensions
@@ -43,7 +51,10 @@ path_edge_tests = [
 
 # note that these tests have no unique solution due to the chosen dimensions
 path_scalar_tests = [
-    ["a,->a", 1,],
+    [
+        "a,->a",
+        1,
+    ],
     ["ab,->ab", 1],
     [",a,->a", 2],
     [",,a,->a", 3],

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -270,6 +270,23 @@ def test_custom_dp_can_set_cost_cap():
     assert info1.opt_cost == info2.opt_cost == info3.opt_cost
 
 
+@pytest.mark.parametrize('minimize,cost,width', [
+    ('flops', 663054, 18900),
+    ('size', 1114440, 2016),
+    ('write', 983790, 2016),
+    ('combo', 973518, 2016),
+    ('limit', 983832, 2016),
+    ('combo-256', 983790, 2016),
+    ('limit-256', 983832, 2016),
+])
+def test_custom_dp_can_set_minimize(minimize, cost, width):
+    eq, shapes = oe.helpers.rand_equation(10, 4, seed=43)
+    opt = oe.DynamicProgramming(minimize=minimize)
+    info = oe.contract_path(eq, *shapes, shapes=True, optimize=opt)[1]
+    assert info.opt_cost == cost
+    assert info.largest_intermediate == width
+
+
 def test_dp_errors_when_no_contractions_found():
     eq, shapes, size_dict = oe.helpers.rand_equation(10, 3, seed=42, return_size_dict=True)
 

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -12,16 +12,8 @@ import pytest
 import opt_einsum as oe
 
 explicit_path_tests = {
-    "GEMM1": (
-        [set("abd"), set("ac"), set("bdc")],
-        set(""),
-        {"a": 1, "b": 2, "c": 3, "d": 4},
-    ),
-    "Inner1": (
-        [set("abcd"), set("abc"), set("bc")],
-        set(""),
-        {"a": 5, "b": 2, "c": 3, "d": 4},
-    ),
+    "GEMM1": ([set("abd"), set("ac"), set("bdc")], set(""), {"a": 1, "b": 2, "c": 3, "d": 4},),
+    "Inner1": ([set("abcd"), set("abc"), set("bc")], set(""), {"a": 5, "b": 2, "c": 3, "d": 4},),
 }
 
 # note that these tests have no unique solution due to the chosen dimensions
@@ -51,10 +43,7 @@ path_edge_tests = [
 
 # note that these tests have no unique solution due to the chosen dimensions
 path_scalar_tests = [
-    [
-        "a,->a",
-        1,
-    ],
+    ["a,->a", 1,],
     ["ab,->ab", 1],
     [",a,->a", 2],
     [",,a,->a", 3],
@@ -270,15 +259,18 @@ def test_custom_dp_can_set_cost_cap():
     assert info1.opt_cost == info2.opt_cost == info3.opt_cost
 
 
-@pytest.mark.parametrize('minimize,cost,width', [
-    ('flops', 663054, 18900),
-    ('size', 1114440, 2016),
-    ('write', 983790, 2016),
-    ('combo', 973518, 2016),
-    ('limit', 983832, 2016),
-    ('combo-256', 983790, 2016),
-    ('limit-256', 983832, 2016),
-])
+@pytest.mark.parametrize(
+    "minimize,cost,width",
+    [
+        ("flops", 663054, 18900),
+        ("size", 1114440, 2016),
+        ("write", 983790, 2016),
+        ("combo", 973518, 2016),
+        ("limit", 983832, 2016),
+        ("combo-256", 983790, 2016),
+        ("limit-256", 983832, 2016),
+    ],
+)
 def test_custom_dp_can_set_minimize(minimize, cost, width):
     eq, shapes = oe.helpers.rand_equation(10, 4, seed=43)
     opt = oe.DynamicProgramming(minimize=minimize)

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -280,7 +280,7 @@ def test_custom_dp_can_set_cost_cap():
         ("limit", 983832, 2016, [(2, 7), (3, 4), (0, 4), (3, 6), (2, 5), (0, 4), (0, 3), (1, 2), (0, 1)]),
         ("combo-256", 983790, 2016, [(0, 8), (3, 4), (1, 4), (5, 6), (1, 5), (0, 4), (0, 3), (1, 2), (0, 1)]),
         ("limit-256", 983832, 2016, [(2, 7), (3, 4), (0, 4), (3, 6), (2, 5), (0, 4), (0, 3), (1, 2), (0, 1)]),
-    ]
+    ],
 )
 def test_custom_dp_can_set_minimize(minimize, cost, width, path):
     eq, shapes = oe.helpers.rand_equation(10, 4, seed=43)

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -271,21 +271,22 @@ def test_custom_dp_can_set_cost_cap():
 
 
 @pytest.mark.parametrize(
-    "minimize,cost,width",
+    "minimize,cost,width,path",
     [
-        ("flops", 663054, 18900),
-        ("size", 1114440, 2016),
-        ("write", 983790, 2016),
-        ("combo", 973518, 2016),
-        ("limit", 983832, 2016),
-        ("combo-256", 983790, 2016),
-        ("limit-256", 983832, 2016),
-    ],
+        ("flops", 663054, 18900, [(4, 5), (2, 5), (2, 7), (5, 6), (1, 5), (1, 4), (0, 3), (0, 2), (0, 1)]),
+        ("size", 1114440, 2016, [(2, 7), (3, 8), (3, 7), (2, 6), (1, 5), (1, 4), (1, 3), (1, 2), (0, 1)]),
+        ("write", 983790, 2016, [(0, 8), (3, 4), (1, 4), (5, 6), (1, 5), (0, 4), (0, 3), (1, 2), (0, 1)]),
+        ("combo", 973518, 2016, [(4, 5), (2, 5), (6, 7), (2, 6), (1, 5), (1, 4), (0, 3), (0, 2), (0, 1)]),
+        ("limit", 983832, 2016, [(2, 7), (3, 4), (0, 4), (3, 6), (2, 5), (0, 4), (0, 3), (1, 2), (0, 1)]),
+        ("combo-256", 983790, 2016, [(0, 8), (3, 4), (1, 4), (5, 6), (1, 5), (0, 4), (0, 3), (1, 2), (0, 1)]),
+        ("limit-256", 983832, 2016, [(2, 7), (3, 4), (0, 4), (3, 6), (2, 5), (0, 4), (0, 3), (1, 2), (0, 1)]),
+    ]
 )
-def test_custom_dp_can_set_minimize(minimize, cost, width):
+def test_custom_dp_can_set_minimize(minimize, cost, width, path):
     eq, shapes = oe.helpers.rand_equation(10, 4, seed=43)
     opt = oe.DynamicProgramming(minimize=minimize)
     info = oe.contract_path(eq, *shapes, shapes=True, optimize=opt)[1]
+    assert info.path == path
     assert info.opt_cost == cost
     assert info.largest_intermediate == width
 


### PR DESCRIPTION
## Description

This adds more custom functions to the dp solver as outlined in #171. For example:
```python
opt = oe.DynamicProgramming(minimize='combo')
```
should give better real world performance in many cases than the pure minimized flop cost alone.
Also included is a couple of 'micro' optimizations  for the path finders performance - namely, making some inner loop calls functions not methods.

## Todos
  - [ ] at some point might be nice to add these to the random greedy path as well

## Questions
- [x]  ~~I tried the black formatter and it showed lots of changes across many files - currently have just committed those on the files modified...? Am I invoking it wrong? (edit: might just be that the conda `black` is a bit out-of-date)~~

## Status
- [x] Ready to go