### PR TITLE
Fully qualify license trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
             'Development Status :: 5 - Production/Stable',
             'Intended Audience :: Science/Research',
             'Intended Audience :: Developers',
-            'License :: OSI Approved',
+            'License :: OSI Approved :: MIT License',
             'Programming Language :: Python',
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
## Description

Fully qualify license trove classifier. This allows tools such as `pip-licenses` to generate a nice license report and matches how other packages in the ecosystem publish their license.

## Status
- [x] Ready to go