### PR TITLE
allow backend=None

### DIFF
--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -550,7 +550,7 @@ def parse_backend(arrays: Sequence[ArrayType], backend: str) -> str:
     """Find out what backend we should use, dipatching based on the first
     array if ``backend='auto'`` is specified.
     """
-    if backend != "auto":
+    if backend not in ("auto", None):
         return backend
     backend = infer_backend(arrays[0])
 

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -4,6 +4,7 @@ Contains the primary optimization and contraction routines.
 
 from collections import namedtuple
 from decimal import Decimal
+from functools import lru_cache
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 from . import backends, blas, helpers, parser, paths, sharing
@@ -542,8 +543,13 @@ def contract(*operands_: Any, **kwargs: Any) -> ArrayType:
     return _core_contract(operands, contraction_list, backend=backend, **einsum_kwargs)
 
 
+@lru_cache(None)
+def _infer_backend_class_cached(cls: type) -> str:
+    return cls.__module__.split(".")[0]
+
+
 def infer_backend(x: Any) -> str:
-    return x.__class__.__module__.split(".")[0]
+    return _infer_backend_class_cached(x.__class__)
 
 
 def parse_backend(arrays: Sequence[ArrayType], backend: Optional[str]) -> str:

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -546,7 +546,7 @@ def infer_backend(x: Any) -> str:
     return x.__class__.__module__.split(".")[0]
 
 
-def parse_backend(arrays: Sequence[ArrayType], backend: str) -> str:
+def parse_backend(arrays: Sequence[ArrayType], backend: Optional[str]) -> str:
     """Find out what backend we should use, dipatching based on the first
     array if ``backend='auto'`` is specified.
     """
@@ -565,7 +565,7 @@ def parse_backend(arrays: Sequence[ArrayType], backend: str) -> str:
 def _core_contract(
     operands_: Sequence[ArrayType],
     contraction_list: ContractionListType,
-    backend: str = "auto",
+    backend: Optional[str] = "auto",
     evaluate_constants: bool = False,
     **einsum_kwargs: Any,
 ) -> ArrayType:
@@ -703,7 +703,7 @@ class ContractExpression:
         self._evaluated_constants: Dict[str, Any] = {}
         self._backend_expressions: Dict[str, Any] = {}
 
-    def evaluate_constants(self, backend: str = "auto") -> None:
+    def evaluate_constants(self, backend: Optional[str] = "auto") -> None:
         """Convert any constant operands to the correct backend form, and
         perform as many contractions as possible to create a new list of
         operands, stored in ``self._evaluated_constants[backend]``. This also
@@ -746,7 +746,7 @@ class ContractExpression:
         self,
         arrays: Sequence[ArrayType],
         out: Optional[ArrayType] = None,
-        backend: str = "auto",
+        backend: Optional[str] = "auto",
         evaluate_constants: bool = False,
     ) -> ArrayType:
         """The normal, core contraction."""

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -556,7 +556,7 @@ def parse_backend(arrays: Sequence[ArrayType], backend: Optional[str]) -> str:
     """Find out what backend we should use, dipatching based on the first
     array if ``backend='auto'`` is specified.
     """
-    if backend not in ("auto", None):
+    if (backend != "auto") and (backend is not None):
         return backend
     backend = infer_backend(arrays[0])
 

--- a/opt_einsum/tests/test_backends.py
+++ b/opt_einsum/tests/test_backends.py
@@ -443,6 +443,7 @@ def test_auto_backend_custom_array_no_tensordot():
     # Shaped is an array-like object defined by opt_einsum - which has no TDOT
     assert infer_backend(x) == "opt_einsum"
     assert parse_backend([x], "auto") == "numpy"
+    assert parse_backend([x], None) == "numpy"
 
 
 @pytest.mark.parametrize("string", tests)


### PR DESCRIPTION
## Description
Allows `backend=None`, which should be fairly unambiguous, as an alternative to 'auto', closes #193.

## Status
- [x] Ready to go