### PR TITLE
Support for Python array API standard

### DIFF
--- a/opt_einsum/backends/__init__.py
+++ b/opt_einsum/backends/__init__.py
@@ -8,7 +8,7 @@ from .dispatch import build_expression, evaluate_constants, get_func, has_backen
 from .tensorflow import to_tensorflow
 from .theano import to_theano
 from .torch import to_torch
-from .array_api import to_array_api, discover_array_api_eps
+from .array_api import to_array_api, discover_array_apis
 
 __all__ = [
     "get_func",
@@ -22,5 +22,5 @@ __all__ = [
     "to_cupy",
     "to_torch",
     "to_array_api",
-    "discover_array_api_eps",
+    "discover_array_apis",
 ]

--- a/opt_einsum/backends/__init__.py
+++ b/opt_einsum/backends/__init__.py
@@ -8,6 +8,7 @@ from .dispatch import build_expression, evaluate_constants, get_func, has_backen
 from .tensorflow import to_tensorflow
 from .theano import to_theano
 from .torch import to_torch
+from .array_api import to_array_api, discover_array_api_eps
 
 __all__ = [
     "get_func",
@@ -20,4 +21,6 @@ __all__ = [
     "to_theano",
     "to_cupy",
     "to_torch",
+    "to_array_api",
+    "discover_array_api_eps",
 ]

--- a/opt_einsum/backends/array_api.py
+++ b/opt_einsum/backends/array_api.py
@@ -1,0 +1,62 @@
+"""
+Required functions for optimized contractions of arrays using array API-compliant backends.
+"""
+import sys
+from importlib.metadata import entry_points
+from typing import Callable
+from types import ModuleType
+
+import numpy as np
+
+from ..sharing import to_backend_cache_wrap
+
+
+def discover_array_api_eps():
+    """Discover array API backends and return their entry points."""
+    if sys.version_info >= (3, 10):
+        return entry_points(group='array_api')
+    else:
+        # Deprecated - will raise warning in Python versions >= 3.10
+        return entry_points().get('array_api', [])
+
+def make_to_array(array_api: ModuleType) -> Callable:
+    """Make a ``to_[array_api]`` function for the given array API."""
+    @to_backend_cache_wrap
+    def to_array(array):  # pragma: no cover
+        if isinstance(array, np.ndarray):
+            return array_api.asarray(array)
+        return array
+    return to_array
+
+def make_build_expression(array_api: ModuleType) -> Callable:
+    """Make a ``build_expression`` function for the given array API."""
+    def build_expression(_, expr):  # pragma: no cover
+        """Build an array API function based on ``arrays`` and ``expr``."""
+        def array_api_contract(*arrays):
+            return expr._contract([make_to_array(array_api)(x) for x in arrays], backend=array_api.__name__)
+        return array_api_contract
+    return build_expression
+
+def make_evaluate_constants(array_api: ModuleType) -> Callable:
+    def evaluate_constants(const_arrays, expr):  # pragma: no cover
+        """Convert constant arguments to cupy arrays, and perform any possible constant contractions.
+        """
+        return expr(*[make_to_array(array_api)(x) for x in const_arrays], backend="cupy", evaluate_constants=True)
+    return evaluate_constants
+
+to_array_api = {}
+build_expression = {}
+evaluate_constants = {}
+
+for ep in discover_array_api_eps():
+    _array_api = ep.load()
+    to_array_api[ep.value] = make_to_array(_array_api)
+    build_expression[ep.value] = make_build_expression(_array_api)
+    evaluate_constants[ep.value] = make_evaluate_constants(_array_api)
+
+__all__ = [
+    'discover_array_api_eps',
+    "to_array_api",
+    "build_expression",
+    "evaluate_constants"
+]

--- a/opt_einsum/backends/dispatch.py
+++ b/opt_einsum/backends/dispatch.py
@@ -15,6 +15,7 @@ from . import object_arrays
 from . import tensorflow as _tensorflow
 from . import theano as _theano
 from . import torch as _torch
+from . import array_api as _array_api
 
 __all__ = [
     "get_func",
@@ -122,6 +123,7 @@ CONVERT_BACKENDS = {
     "cupy": _cupy.build_expression,
     "torch": _torch.build_expression,
     "jax": _jax.build_expression,
+    **_array_api.build_expression,
 }
 
 EVAL_CONSTS_BACKENDS = {
@@ -130,8 +132,8 @@ EVAL_CONSTS_BACKENDS = {
     "cupy": _cupy.evaluate_constants,
     "torch": _torch.evaluate_constants,
     "jax": _jax.evaluate_constants,
+    **_array_api.evaluate_constants,
 }
-
 
 def build_expression(backend, arrays, expr):
     """Build an expression, based on ``expr`` and initial arrays ``arrays``,

--- a/opt_einsum/tests/test_backends.py
+++ b/opt_einsum/tests/test_backends.py
@@ -1,6 +1,4 @@
 from types import ModuleType
-import sys
-import importlib
 import numpy as np
 from pkg_resources import EntryPoint
 import pytest
@@ -61,8 +59,8 @@ except ImportError:
     found_autograd = False
 
 
-@pytest.fixture(params=backends.discover_array_api_eps())
-def array_api_ep(request) -> importlib.metadata.EntryPoint:
+@pytest.fixture(params=backends.discover_array_apis())
+def array_api(request) -> ModuleType:
     return request.param
 
 
@@ -476,10 +474,10 @@ def test_object_arrays_backend(string):
     assert obj_opt.dtype == object
     assert np.allclose(ein, obj_opt.astype(float))
 
+
 @pytest.mark.parametrize("string", tests)
-def test_array_api(array_api_ep: EntryPoint, string):  # pragma: no cover
-    array_api: ModuleType = array_api_ep.load()
-    array_api_qname: str = array_api_ep.value
+def test_array_api(array_api: ModuleType, string):  # pragma: no cover
+    array_api_qname: str = array_api.__name__
     
     views = helpers.build_views(string)
     ein = contract(string, *views, optimize=False, use_blas=False)

--- a/opt_einsum/tests/test_sharing.py
+++ b/opt_einsum/tests/test_sharing.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from opt_einsum import contract, contract_expression, contract_path, get_symbol, helpers, shared_intermediates
-from opt_einsum.backends import to_cupy, to_torch
+from opt_einsum.backends import to_cupy, to_torch, to_array_api, discover_array_api_eps
 from opt_einsum.contract import _einsum
 from opt_einsum.parser import parse_einsum_input
 from opt_einsum.sharing import count_cached_ops, currently_sharing, get_sharing_cache
@@ -25,7 +25,9 @@ try:
 except ImportError:
     torch_if_found = pytest.param("torch", marks=[pytest.mark.skip(reason="PyTorch not installed.")])  # type: ignore
 
-backends = ["numpy", torch_if_found, cupy_if_found]
+array_api_qnames = [ep.value for ep in discover_array_api_eps()]
+
+backends = ["numpy", torch_if_found, cupy_if_found, *array_api_qnames]
 equations = [
     "ab,bc->ca",
     "abc,bcd,dea",
@@ -41,6 +43,7 @@ to_backend = {
     "numpy": lambda x: x,
     "torch": to_torch,
     "cupy": to_cupy,
+    **to_array_api,
 }
 
 
@@ -55,7 +58,7 @@ def test_sharing_value(eq, backend):
     with shared_intermediates():
         actual = expr(*views, backend=backend)
 
-    assert (actual == expected).all()
+    assert np.all(actual == expected)
 
 
 @pytest.mark.parametrize("backend", backends)

--- a/opt_einsum/tests/test_sharing.py
+++ b/opt_einsum/tests/test_sharing.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from opt_einsum import contract, contract_expression, contract_path, get_symbol, helpers, shared_intermediates
-from opt_einsum.backends import to_cupy, to_torch, to_array_api, discover_array_api_eps
+from opt_einsum.backends import to_cupy, to_torch
 from opt_einsum.contract import _einsum
 from opt_einsum.parser import parse_einsum_input
 from opt_einsum.sharing import count_cached_ops, currently_sharing, get_sharing_cache
@@ -25,9 +25,7 @@ try:
 except ImportError:
     torch_if_found = pytest.param("torch", marks=[pytest.mark.skip(reason="PyTorch not installed.")])  # type: ignore
 
-array_api_qnames = [ep.value for ep in discover_array_api_eps()]
-
-backends = ["numpy", torch_if_found, cupy_if_found, *array_api_qnames]
+backends = ["numpy", torch_if_found, cupy_if_found]
 equations = [
     "ab,bc->ca",
     "abc,bcd,dea",
@@ -43,7 +41,6 @@ to_backend = {
     "numpy": lambda x: x,
     "torch": to_torch,
     "cupy": to_cupy,
-    **to_array_api,
 }
 
 
@@ -58,7 +55,7 @@ def test_sharing_value(eq, backend):
     with shared_intermediates():
         actual = expr(*views, backend=backend)
 
-    assert np.all(actual == expected)
+    assert (actual == expected).all()
 
 
 @pytest.mark.parametrize("backend", backends)


### PR DESCRIPTION
## Description
This PR adds support for libraries that conform to the [Python array API standard](https://data-apis.org/array-api/latest/index.html). It discovers complying modules upon import of opt_einsum.

Eventually (and hopefully soon), once the array API standard becomes ubiquitous, this should largely eliminate the need for backend-specific code.

## Todos
  - [x] Tests
  - [ ] Update docs

## Status
- [x] Ready to go