### PR TITLE
[BUG FIX] Add shapes support to parse_einsum_input

### DIFF
--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -129,7 +129,7 @@ def contract_path(*operands_: Any, **kwargs: Any) -> Tuple[PathType, PathInfo]:
     **Parameters:**
 
     - **subscripts** - *(str)* Specifies the subscripts for summation.
-    - **\\*operands** - *(list of array_like)* hese are the arrays for the operation.
+    - **\\*operands** - *(list of array_like)* these are the arrays for the operation.
     - **use_blas** - *(bool)* Do you use BLAS for valid operations, may use extra memory for more intermediates.
     - **optimize** - *(str, list or bool, optional (default: `auto`))* Choose the type of path.
 
@@ -251,7 +251,7 @@ def contract_path(*operands_: Any, **kwargs: Any) -> Tuple[PathType, PathInfo]:
     use_blas = kwargs.pop("use_blas", True)
 
     # Python side parsing
-    input_subscripts, output_subscript, operands = parser.parse_einsum_input(operands_)
+    input_subscripts, output_subscript, operands = parser.parse_einsum_input(operands_, shapes=shapes)
 
     # Build a few useful list and sets
     input_list = input_subscripts.split(",")

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -3,7 +3,7 @@ A functionally equivalent parser of the numpy.einsum input parser
 """
 
 import itertools
-from typing import Any, Dict, Iterator, List, Tuple
+from typing import Any, Dict, Iterator, List, Tuple, Union
 
 import numpy as np
 
@@ -224,7 +224,7 @@ def convert_subscripts(old_sub: List[Any], symbol_map: Dict[Any, Any]) -> str:
     return new_sub
 
 
-def convert_interleaved_input(operands: List[Any]) -> Tuple[str, List[Any]]:
+def convert_interleaved_input(operands: Union[List[Any], Tuple[Any]]) -> Tuple[str, List[Any]]:
     """Convert 'interleaved' input to standard einsum input."""
     tmp_operands = list(operands)
     operand_list = []
@@ -262,7 +262,7 @@ def convert_interleaved_input(operands: List[Any]) -> Tuple[str, List[Any]]:
     return subscripts, operands
 
 
-def parse_einsum_input(*operands: Any, shapes: bool = False) -> Tuple[str, str, List[ArrayType]]:
+def parse_einsum_input(operands: Any, shapes: bool = False) -> Tuple[str, str, List[ArrayType]]:
     """
     A reproduction of einsum c side einsum parsing in python.
 

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -262,9 +262,15 @@ def convert_interleaved_input(operands: List[Any]) -> Tuple[str, List[Any]]:
     return subscripts, operands
 
 
-def parse_einsum_input(operands: Any) -> Tuple[str, str, List[ArrayType]]:
+def parse_einsum_input(operands: Any, **kwargs: Any) -> Tuple[str, str, List[ArrayType]]:
     """
     A reproduction of einsum c side einsum parsing in python.
+
+    **Parameters:**
+    Intakes the same inputs as `contract_path`, but NOT the keyword args. The only
+    supported keyword argument is:
+    - **shapes** - *(bool, optional)* Whether ``parse_einsum_input`` should assume arrays (the default) or
+        array shapes have been supplied.
 
     Returns
     -------
@@ -288,15 +294,27 @@ def parse_einsum_input(operands: Any) -> Tuple[str, str, List[ArrayType]]:
     ('za,xza', 'xz', [a, b])
     """
 
+    # Make sure all keywords are valid
+    unknown_kwargs = set(kwargs) - {"shapes"}
+    if len(unknown_kwargs):
+        raise TypeError("parse_einsum_input: Did not understand the following kwargs: {}".format(unknown_kwargs))
+
+    shapes = kwargs.pop("shapes", False)
+
     if len(operands) == 0:
         raise ValueError("No input operands")
 
     if isinstance(operands[0], str):
         subscripts = operands[0].replace(" ", "")
-        operands = [possibly_convert_to_numpy(x) for x in operands[1:]]
-
+        if not shapes:
+            operands = [possibly_convert_to_numpy(x) for x in operands[1:]]
     else:
         subscripts, operands = convert_interleaved_input(operands)
+
+    if shapes:
+        operand_shapes = operands
+    else:
+        operand_shapes = [o.shape for o in operands]
 
     # Check for proper "->"
     if ("-" in subscripts) or (">" in subscripts):
@@ -307,7 +325,7 @@ def parse_einsum_input(operands: Any) -> Tuple[str, str, List[ArrayType]]:
     # Parse ellipses
     if "." in subscripts:
         used = subscripts.replace(".", "").replace(",", "").replace("->", "")
-        ellipse_inds = "".join(gen_unused_symbols(used, max(len(x.shape) for x in operands)))
+        ellipse_inds = "".join(gen_unused_symbols(used, max(len(x) for x in operand_shapes)))
         longest = 0
 
         # Do we have an output to account for?
@@ -325,10 +343,10 @@ def parse_einsum_input(operands: Any) -> Tuple[str, str, List[ArrayType]]:
                     raise ValueError("Invalid Ellipses.")
 
                 # Take into account numerical values
-                if operands[num].shape == ():
+                if operand_shapes[num] == ():
                     ellipse_count = 0
                 else:
-                    ellipse_count = max(len(operands[num].shape), 1) - (len(sub) - 3)
+                    ellipse_count = max(len(operand_shapes[num]), 1) - (len(sub) - 3)
 
                 if ellipse_count > longest:
                     longest = ellipse_count

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -306,8 +306,7 @@ def parse_einsum_input(operands: Any, **kwargs: Any) -> Tuple[str, str, List[Arr
 
     if isinstance(operands[0], str):
         subscripts = operands[0].replace(" ", "")
-        if not shapes:
-            operands = [possibly_convert_to_numpy(x) for x in operands[1:]]
+        operands = [possibly_convert_to_numpy(x) for x in operands[1:]]
     else:
         subscripts, operands = convert_interleaved_input(operands)
 
@@ -388,6 +387,7 @@ def parse_einsum_input(operands: Any, **kwargs: Any) -> Tuple[str, str, List[Arr
 
     # Make sure number operands is equivalent to the number of terms
     if len(input_subscripts.split(",")) != len(operands):
-        raise ValueError("Number of einsum subscripts must be equal to the " "number of operands.")
+        raise ValueError(f"Number of einsum subscripts, {len(input_subscripts.split(','))}, must be equal to the "
+                         f"number of operands, {len(operands)}.")
 
     return input_subscripts, output_subscript, operands

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -299,6 +299,12 @@ def parse_einsum_input(operands: Any, shapes: bool = False) -> Tuple[str, str, L
 
     if isinstance(operands[0], str):
         subscripts = operands[0].replace(" ", "")
+        if shapes:
+            if any([hasattr(o, "shape") for o in operands[1:]]):
+                raise ValueError(
+                    "shapes is set to True but given at least one operand looks like an array"
+                    " (at least one operand has a shape attribute). "
+                )
         operands = [possibly_convert_to_numpy(x) for x in operands[1:]]
     else:
         subscripts, operands = convert_interleaved_input(operands)

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -262,7 +262,7 @@ def convert_interleaved_input(operands: List[Any]) -> Tuple[str, List[Any]]:
     return subscripts, operands
 
 
-def parse_einsum_input(operands: Any, **kwargs: Any) -> Tuple[str, str, List[ArrayType]]:
+def parse_einsum_input(*operands: Any, shapes: bool = False) -> Tuple[str, str, List[ArrayType]]:
     """
     A reproduction of einsum c side einsum parsing in python.
 
@@ -293,13 +293,6 @@ def parse_einsum_input(operands: Any, **kwargs: Any) -> Tuple[str, str, List[Arr
     >>> parse_einsum_input((a, [Ellipsis, 0], b, [Ellipsis, 0]))
     ('za,xza', 'xz', [a, b])
     """
-
-    # Make sure all keywords are valid
-    unknown_kwargs = set(kwargs) - {"shapes"}
-    if len(unknown_kwargs):
-        raise TypeError("parse_einsum_input: Did not understand the following kwargs: {}".format(unknown_kwargs))
-
-    shapes = kwargs.pop("shapes", False)
 
     if len(operands) == 0:
         raise ValueError("No input operands")

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -387,7 +387,9 @@ def parse_einsum_input(operands: Any, **kwargs: Any) -> Tuple[str, str, List[Arr
 
     # Make sure number operands is equivalent to the number of terms
     if len(input_subscripts.split(",")) != len(operands):
-        raise ValueError(f"Number of einsum subscripts, {len(input_subscripts.split(','))}, must be equal to the "
-                         f"number of operands, {len(operands)}.")
+        raise ValueError(
+            f"Number of einsum subscripts, {len(input_subscripts.split(','))}, must be equal to the "
+            f"number of operands, {len(operands)}."
+        )
 
     return input_subscripts, output_subscript, operands

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -1248,7 +1248,7 @@ class DynamicProgramming(PathOptimizer):
             # the set of n tensors is represented by a bitmap: if bit j is 1,
             # tensor j is in the set, e.g. 0b100101 = {0,2,5}; set unions
             # (intersections) can then be computed by bitwise or (and);
-            x: List[Any] = [None] * 2 + [dict() for j in range(len(g) - 1)]  # type: ignore
+            x: List[Any] = [None] * 2 + [dict() for j in range(len(g) - 1)]
             x[1] = OrderedDict((1 << j, (inputs[j], 0, inputs_contractions[j])) for j in g)
 
             # convert set of tensors g to a bitmap set:

--- a/opt_einsum/tests/test_parser.py
+++ b/opt_einsum/tests/test_parser.py
@@ -2,7 +2,8 @@
 Directly tests various parser utility functions.
 """
 
-from opt_einsum.parser import get_symbol
+import numpy as np
+from opt_einsum.parser import get_symbol, parse_einsum_input, possibly_convert_to_numpy
 
 
 def test_get_symbol():
@@ -12,3 +13,21 @@ def test_get_symbol():
     assert get_symbol(55295) == "\ud88b"
     assert get_symbol(55296) == "\ue000"
     assert get_symbol(57343) == "\ue7ff"
+
+
+def test_parse_einsum_input():
+    eq = "ab,bc,cd"
+    ops = [np.random.rand(2, 3), np.random.rand(3, 4), np.random.rand(4, 5)]
+    input_subscripts, output_subscript, operands = parse_einsum_input(eq, *ops, shapes=True)
+    assert input_subscripts == eq
+    assert output_subscript == "ad"
+    assert operands == ops
+
+
+def test_parse_einsum_input_shapes():
+    eq = "ab,bc,cd"
+    shps = [(2, 3), (3, 4), (4, 5)]
+    input_subscripts, output_subscript, operands = parse_einsum_input(eq, *shps, shapes=True)
+    assert input_subscripts == eq
+    assert output_subscript == "ad"
+    assert np.allclose([possibly_convert_to_numpy(shp) for shp in shps], operands)

--- a/opt_einsum/tests/test_parser.py
+++ b/opt_einsum/tests/test_parser.py
@@ -2,7 +2,9 @@
 Directly tests various parser utility functions.
 """
 
+from multiprocessing.sharedctypes import Value
 import numpy as np
+import pytest
 from opt_einsum.parser import get_symbol, parse_einsum_input, possibly_convert_to_numpy
 
 
@@ -28,13 +30,8 @@ def test_parse_einsum_input_shapes_error():
     eq = "ab,bc,cd"
     ops = [np.random.rand(2, 3), np.random.rand(3, 4), np.random.rand(4, 5)]
 
-    try:
+    with pytest.raises(ValueError):
         _ = parse_einsum_input([eq, *ops], shapes=True)
-    except ValueError:
-        return
-
-    # raise error when shapes is True but the operands still look like arrays
-    assert False
 
 
 def test_parse_einsum_input_shapes():

--- a/opt_einsum/tests/test_parser.py
+++ b/opt_einsum/tests/test_parser.py
@@ -18,7 +18,7 @@ def test_get_symbol():
 def test_parse_einsum_input():
     eq = "ab,bc,cd"
     ops = [np.random.rand(2, 3), np.random.rand(3, 4), np.random.rand(4, 5)]
-    input_subscripts, output_subscript, operands = parse_einsum_input(eq, *ops, shapes=True)
+    input_subscripts, output_subscript, operands = parse_einsum_input([eq, *ops], shapes=True)
     assert input_subscripts == eq
     assert output_subscript == "ad"
     assert operands == ops
@@ -27,7 +27,7 @@ def test_parse_einsum_input():
 def test_parse_einsum_input_shapes():
     eq = "ab,bc,cd"
     shps = [(2, 3), (3, 4), (4, 5)]
-    input_subscripts, output_subscript, operands = parse_einsum_input(eq, *shps, shapes=True)
+    input_subscripts, output_subscript, operands = parse_einsum_input([eq, *shps], shapes=True)
     assert input_subscripts == eq
     assert output_subscript == "ad"
     assert np.allclose([possibly_convert_to_numpy(shp) for shp in shps], operands)

--- a/opt_einsum/tests/test_parser.py
+++ b/opt_einsum/tests/test_parser.py
@@ -18,7 +18,7 @@ def test_get_symbol():
 def test_parse_einsum_input():
     eq = "ab,bc,cd"
     ops = [np.random.rand(2, 3), np.random.rand(3, 4), np.random.rand(4, 5)]
-    input_subscripts, output_subscript, operands = parse_einsum_input([eq, *ops], shapes=True)
+    input_subscripts, output_subscript, operands = parse_einsum_input([eq, *ops])
     assert input_subscripts == eq
     assert output_subscript == "ad"
     assert operands == ops

--- a/opt_einsum/tests/test_parser.py
+++ b/opt_einsum/tests/test_parser.py
@@ -24,6 +24,19 @@ def test_parse_einsum_input():
     assert operands == ops
 
 
+def test_parse_einsum_input_shapes_error():
+    eq = "ab,bc,cd"
+    ops = [np.random.rand(2, 3), np.random.rand(3, 4), np.random.rand(4, 5)]
+
+    try:
+        _ = parse_einsum_input([eq, *ops], shapes=True)
+    except ValueError:
+        return
+
+    # raise error when shapes is True but the operands still look like arrays
+    assert False
+
+
 def test_parse_einsum_input_shapes():
     eq = "ab,bc,cd"
     shps = [(2, 3), (3, 4), (4, 5)]


### PR DESCRIPTION
## Description
This PR adds support for the shapes kwarg for `parse_einsum_input`. This also fixes a bug where `contract_path` takes in the shapes parameter but `parse_einsum_input` is called without respecting the shapes parameter.

The bug results because even though the user had input shapes as True, `contract_path` will call `parse_einsum_input` _before_ caring about shapes, and within `parse_einsum_input`, will call .shape on an array that is already a shape.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add support for the shapes kwarg in parse_einsum_input
  - [x] Pass along the shapes kwarg in the call from contract_path

## Questions
- [x] The lint failure looks to be infra flakiness--how can I rerun?

## Status
- [x] Ready to go