### PR TITLE
Disable torch.backends.opt_einsum to avoid duplicate work

### DIFF
--- a/opt_einsum/backends/torch.py
+++ b/opt_einsum/backends/torch.py
@@ -46,16 +46,18 @@ def transpose(a, axes):
 def get_einsum():
     torch, _ = _get_torch_and_device()
     if hasattr(torch, "_VF") and hasattr(torch._VF, "einsum"):
-        print("called")
+        print("returning VF")
         return torch._VF.einsum
-    print("did not get called")
 
+    if not hasattr(torch, "backends") or not hasattr(torch.backends, "opt_einsum"):
+        print("returning normal torch")
+        return torch.einsum
+    
     def einsum_no_opt(*args, **kwargs):
-        if hasattr(torch, "backends") and hasattr(torch.backends, "opt_einsum"):
-            with torch.backends.opt_einsum.flags(enabled=False):
-                return torch.einsum(*args, **kwargs)
-        return torch.einsum(*args, **kwargs)
-
+        with torch.backends.opt_einsum.flags(enabled=False):
+            return torch.einsum(*args, **kwargs)
+    
+    print("returning normal torch with opt off")
     return einsum_no_opt
 
 

--- a/opt_einsum/backends/torch.py
+++ b/opt_einsum/backends/torch.py
@@ -48,6 +48,9 @@ def einsum(equation, *operands):
     equation = convert_to_valid_einsum_chars(equation)
 
     torch, _ = _get_torch_and_device()
+    # disable opt_einsum in torch so that it does not recompute any path
+    if hasattr(torch, "backends") and hasattr(torch.backends, "opt_einsum"):
+        torch.backends.opt_einsum.enabled = False
     return torch.einsum(equation, operands)
 
 

--- a/opt_einsum/backends/torch.py
+++ b/opt_einsum/backends/torch.py
@@ -41,18 +41,21 @@ def transpose(a, axes):
     """Normal torch transpose is only valid for 2D matrices."""
     return a.permute(*axes)
 
+
 @lru_cache(None)
 def get_einsum():
     torch, _ = _get_torch_and_device()
     if hasattr(torch, "_VF") and hasattr(torch._VF, "einsum"):
         print("called")
         return torch._VF.einsum
+    print("did not get called")
 
     def einsum_no_opt(*args, **kwargs):
         if hasattr(torch, "backends") and hasattr(torch.backends, "opt_einsum"):
             with torch.backends.opt_einsum.flags(enabled=False):
                 return torch.einsum(*args, **kwargs)
         return torch.einsum(*args, **kwargs)
+
     return einsum_no_opt
 
 

--- a/opt_einsum/tests/test_contract.py
+++ b/opt_einsum/tests/test_contract.py
@@ -198,6 +198,17 @@ def test_contract_expression_interleaved_input():
     assert np.allclose(out, expected)
 
 
+def test_torch_contract_expression_interleaved_input():
+    import torch
+
+    x, y, z = (torch.randn(2, 2) for _ in "xyz")
+    expected = np.einsum(x, [0, 1], y, [1, 2], z, [2, 3], [3, 0])
+    xshp, yshp, zshp = ((2, 2) for _ in "xyz")
+    expr = contract_expression(xshp, [0, 1], yshp, [1, 2], zshp, [2, 3], [3, 0])
+    out = expr(x, y, z)
+    assert np.allclose(out, expected)
+
+
 @pytest.mark.parametrize(
     "string,constants",
     [

--- a/opt_einsum/tests/test_contract.py
+++ b/opt_einsum/tests/test_contract.py
@@ -1,5 +1,5 @@
 """
-Tets a series of opt_einsum contraction paths to ensure the results are the same for different paths
+Tests a series of opt_einsum contraction paths to ensure the results are the same for different paths
 """
 
 import numpy as np


### PR DESCRIPTION
## Description
Recently, `torch.einsum` has improved to automatically optimize for multi-contractions if the opt_einsum library is installed. This way, torch users can reap benefits easily. However, this change may inadvertently cause regressions for those who use `opt_einsum.contract` with torch tensors. While these use cases can be improved by just changing `opt_einsum.contract` calls to `torch.einsum`, it is not right to cause silent regressions. 

Consider the following example:
```
import torch
import opt_einsum

A = torch.rand(4, 5)
B = torch.rand(5, 6)
C = torch.rand(6, 7) 
D = opt_einsum.contract('ij,jk,kl->il', A, B, C)
```

Looking through the code, `opt_einsum.contract` will figure out an ideal path + return that path in the form of contraction tuples (commonly pairs). Then, for each of the contraction tuples, `opt_einsum` may call BACK into the torch backend and call `torch.einsum`.

Since the contractions are commonly pairs, calling back into torch.einsum will do what it used to--just directly do the contraction. 

HOWEVER. There are cases where the contractions are not necessarily pairs (@dgasmith had mentioned that hadamard products are faster when chained vs staggered in pairs) and in this case, `torch.einsum` will do unnecessary work in recomputing an ideal path, which is a regression from the previous state.

This PR simply asks "hey, does the opt_einsum backend exist in torch?" If so, this means `torch.einsum` will do the unnecessary work in recomputing an ideal path, so let's just turn it off.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add the code to disable torch's opt_einsum optimization
  - [ ] Test cases? 

## Questions
- [ ] Unsure how to best test this/what use case would ensure that, without this code, the path would be computed more than once, and after this code, the path would only be computed at the top level. We could just test that torch.backends.opt_einsum.enabled is globally False, I guess.

## Status
- [ ] Ready to go