### PR TITLE
Use ConfigParser instead of SafeConfigParser

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
The SafeConfigParser class will be renamed to ConfigParser in Python 3.12 [1]. This alias will be removed in future versions.So we can use ConfigParser directly instead.

[1] https://github.com/python/cpython/issues/89336

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>

## Description
Provide a brief description of the PR's purpose here.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go