### PR TITLE
Fixes `operands could not be broadcast` error when the subscripts contain ellipsis and the operands are shapes.

### DIFF
--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -309,8 +309,8 @@ def parse_einsum_input(operands: Any, shapes: bool = False) -> Tuple[str, str, L
     else:
         subscripts, operands = convert_interleaved_input(operands)
 
-    if shapes:
-        operand_shapes = operands
+   if shapes:
+        operand_shapes = [list(s) for s in operands]
     else:
         operand_shapes = [o.shape for o in operands]
 

--- a/opt_einsum/parser.py
+++ b/opt_einsum/parser.py
@@ -309,7 +309,7 @@ def parse_einsum_input(operands: Any, shapes: bool = False) -> Tuple[str, str, L
     else:
         subscripts, operands = convert_interleaved_input(operands)
 
-   if shapes:
+    if shapes:
         operand_shapes = [list(s) for s in operands]
     else:
         operand_shapes = [o.shape for o in operands]

--- a/opt_einsum/tests/test_parser.py
+++ b/opt_einsum/tests/test_parser.py
@@ -41,3 +41,12 @@ def test_parse_einsum_input_shapes() -> None:
     assert input_subscripts == eq
     assert output_subscript == "ad"
     assert np.allclose([possibly_convert_to_numpy(shp) for shp in shps], operands)
+
+
+def test_parse_with_ellisis():
+    eq = "...a,ab"
+    shps = [(2, 3), (3, 4)]
+    input_subscripts, output_subscript, operands = parse_einsum_input([eq, *shps], shapes=True)
+    assert input_subscripts == "da,ab"
+    assert output_subscript == "db"
+    assert np.allclose([possibly_convert_to_numpy(shp) for shp in shps], operands)


### PR DESCRIPTION
## Description
When the subscript contain ellipsis and operands are shape, we get the following error:
```
ValueError: operands could not be broadcast together with shapes (..)
```
This is due to the fact that the parser converts the operands into numpy arrays which have strict rules on comparison.

This PR addresses https://github.com/dgasmith/opt_einsum/issues/235.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] enforce operand shapes to be list of lists
  - [x] adds a unittest to verify the fixed behavior

## Status
- [ ] Ready to go