### PR TITLE
v3.4 Release notes and removes NumPy kwargs

### DIFF
--- a/devtools/conda-envs/full-environment.yaml
+++ b/devtools/conda-envs/full-environment.yaml
@@ -16,7 +16,7 @@ dependencies:
 
     # Testing
   - codecov
-  - mypy
+  - mypy ==1.11*
   - pytest
   - pytest-cov
   - ruff ==0.5.*

--- a/devtools/conda-envs/min-deps-environment.yaml
+++ b/devtools/conda-envs/min-deps-environment.yaml
@@ -7,7 +7,7 @@ dependencies:
 
     # Testing
   - codecov
-  - mypy
+  - mypy ==1.11*
   - pytest
   - pytest-cov
-  - ruff ==0.5.*
+  - ruff ==0.6.*

--- a/devtools/conda-envs/min-ver-environment.yaml
+++ b/devtools/conda-envs/min-ver-environment.yaml
@@ -13,7 +13,7 @@ dependencies:
 
     # Testing
   - codecov
-  - mypy
+  - mypy ==1.11*
   - pytest
   - pytest-cov
   - ruff ==0.5.*

--- a/devtools/conda-envs/torch-only-environment.yaml
+++ b/devtools/conda-envs/torch-only-environment.yaml
@@ -11,7 +11,7 @@ dependencies:
 
     # Testing
   - codecov
-  - mypy
+  - mypy ==1.11*
   - pytest
   - pytest-cov
   - ruff ==0.5.*

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,7 @@ NumPy has been removed from `opt_einsum` as a dependency allowing for more flexi
 
  - [\#160](https://github.com/dgasmith/opt_einsum/pull/160) Migrates docs to MkDocs Material and GitHub pages hosting.
  - [\#161](https://github.com/dgasmith/opt_einsum/pull/161) Adds Python type annotations to the code base.
- - [\#204](https://github.com/dgasmith/opt_einsum/pull/204) Removes NumPy as a hard dependancy.
+ - [\#204](https://github.com/dgasmith/opt_einsum/pull/204) Removes NumPy as a hard dependency.
 
 **Enhancements**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ NumPy has been removed from `opt_einsum` as a dependancy allowing for more flexi
 **New Features**
 
  - [\#160](https://github.com/dgasmith/opt_einsum/pull/160) Migrates docs to MkDocs Material and GitHub pages hosting.
- - [\#161](https://github.com/dgasmith/opt_einsum/pull/161) Add type annotations to the code base.
+ - [\#161](https://github.com/dgasmith/opt_einsum/pull/161) Adds Python type annotations to the code base.
  - [\#204](https://github.com/dgasmith/opt_einsum/pull/204) Removes NumPy as a hard dependancy.
 
 **Enhancements**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,35 @@
 Changelog
 =========
 
+## 3.4.0 / 2024-09-XX
+
+NumPy has been removed from `opt_einsum` as a dependancy allowing for more flexible installs.
+
+**New Features**
+
+ - [\#160](https://github.com/dgasmith/opt_einsum/pull/160) Migrates docs to MkDocs Material and GitHub pages hosting.
+ - [\#161](https://github.com/dgasmith/opt_einsum/pull/161) Add type annotations to the code base.
+ - [\#204](https://github.com/dgasmith/opt_einsum/pull/204) Removes NumPy as a hard dependancy.
+
+**Enhancements**
+
+- [\#154](https://github.com/dgasmith/opt_einsum/pull/154) Prevents an infinite recursion error when the `memory_limit` was set very low for the `dp` algorithm. 
+- [\#155](https://github.com/dgasmith/opt_einsum/pull/155) Adds flake8 spell check to the doc strings
+- [\#159](https://github.com/dgasmith/opt_einsum/pull/159) Migrates to GitHub actions for CI.
+- [\#174](https://github.com/dgasmith/opt_einsum/pull/174) Prevents double contracts of floats in dynamic paths.
+- [\#196](https://github.com/dgasmith/opt_einsum/pull/196) Allows `backend=None` which is equivalent to `backend='auto'`
+- [\#208](https://github.com/dgasmith/opt_einsum/pull/208) Switches to `ConfigParser` insetad of `SafeConfigParser` for Python 3.12 compatability. 
+- [\#228](https://github.com/dgasmith/opt_einsum/pull/228) `backend='jaxlib'` is now an alias for the `jax` library
+- [\#237](https://github.com/dgasmith/opt_einsum/pull/237) Switches to `ruff` for formatting and linting.
+- [\#238](https://github.com/dgasmith/opt_einsum/pull/238) Removes `numpy`-specific keyword args from being explicitly defined in `contract` and uses `**kwargs` instead.
+
+**Bug Fixes**
+
+- [\#195](https://github.com/dgasmith/opt_einsum/pull/195) Fixes a bug where `dp` would not work for scalar-only contractions.
+- [\#200](https://github.com/dgasmith/opt_einsum/pull/200) Fixes a bug where `parse_einsum_input` would not correctly respect shape-only contractions.
+- [\#222](https://github.com/dgasmith/opt_einsum/pull/222) Fixes an erorr in `parse_einsum_input` where an output subscript specified multiple times was not correctly caught. 
+- [\#229](https://github.com/dgasmith/opt_einsum/pull/229) Fixes a bug where empty contraction lists in `PathInfo` would cause an error.
+
 ## 3.3.0 / 2020-07-19
 
 Adds a `object` backend for optimized contractions on arbitrary Python objects.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@ Changelog
 
 ## 3.4.0 / 2024-09-XX
 
-NumPy has been removed from `opt_einsum` as a dependancy allowing for more flexible installs.
+NumPy has been removed from `opt_einsum` as a dependency allowing for more flexible installs.
 
 **New Features**
 

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -281,7 +281,7 @@ def contract_path(
       #>    5               defg,hd->efgh                               efgh->efgh
       ```
     """
-    if optimize is True:
+    if (optimize is True) or (optimize is None):
         optimize = "auto"
 
     # Hidden option, only einsum should call this
@@ -341,9 +341,11 @@ def contract_path(
     naive_cost = helpers.flop_count(indices, inner_product, num_ops, size_dict)
 
     # Compute the path
-    if not isinstance(optimize, (str, paths.PathOptimizer)):
+    if optimize is False:
+        path_tuple: PathType = [tuple(range(num_ops))]
+    elif not isinstance(optimize, (str, paths.PathOptimizer)):
         # Custom path supplied
-        path_tuple: PathType = optimize  # type: ignore
+        path_tuple = optimize  # type: ignore
     elif num_ops <= 2:
         # Nothing to be optimized
         path_tuple = [tuple(range(num_ops))]
@@ -536,11 +538,12 @@ def contract(
             - `'branch-2'` An even more restricted version of 'branch-all' that
             only searches the best two options at each step. Scales exponentially
             with the number of terms in the contraction.
-            - `'auto'` Choose the best of the above algorithms whilst aiming to
+            - `'auto', None, True` Choose the best of the above algorithms whilst aiming to
             keep the path finding time below 1ms.
             - `'auto-hq'` Aim for a high quality contraction, choosing the best
             of the above algorithms whilst aiming to keep the path finding time
             below 1sec.
+            - `False` will not optimize the contraction.
 
         memory_limit:- Give the upper bound of the largest intermediate tensor contract will build.
             - None or -1 means there is no limit.
@@ -571,7 +574,7 @@ def contract(
         performed optimally. When NumPy is linked to a threaded BLAS, potential
         speedups are on the order of 20-100 for a six core machine.
     """
-    if optimize is True:
+    if (optimize is True) or (optimize is None):
         optimize = "auto"
 
     operands_list = [subscripts] + list(operands)

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -500,9 +500,13 @@ def branch(
     size_dict: Dict[str, int],
     memory_limit: Optional[int] = None,
     nbranch: Optional[int] = None,
-    **optimizer_kwargs: Dict[str, Any],
+    cutoff_flops_factor: int = 4,
+    minimize: str = "flops",
+    cost_fn: str = "memory-removed",
 ) -> PathType:
-    optimizer = BranchBound(nbranch=nbranch, **optimizer_kwargs)  # type: ignore
+    optimizer = BranchBound(
+        nbranch=nbranch, cutoff_flops_factor=cutoff_flops_factor, minimize=minimize, cost_fn=cost_fn
+    )
     return optimizer(inputs, output, size_dict, memory_limit)
 
 

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -502,7 +502,7 @@ def branch(
     nbranch: Optional[int] = None,
     **optimizer_kwargs: Dict[str, Any],
 ) -> PathType:
-    optimizer = BranchBound(nbarnch=nbranch, **optimizer_kwargs)  # type: ignore
+    optimizer = BranchBound(nbranch=nbranch, **optimizer_kwargs)  # type: ignore
     return optimizer(inputs, output, size_dict, memory_limit)
 
 

--- a/opt_einsum/paths.py
+++ b/opt_einsum/paths.py
@@ -499,9 +499,10 @@ def branch(
     output: ArrayIndexType,
     size_dict: Dict[str, int],
     memory_limit: Optional[int] = None,
+    nbranch: Optional[int] = None,
     **optimizer_kwargs: Dict[str, Any],
 ) -> PathType:
-    optimizer = BranchBound(**optimizer_kwargs)  # type: ignore
+    optimizer = BranchBound(nbarnch=nbranch, **optimizer_kwargs)  # type: ignore
     return optimizer(inputs, output, size_dict, memory_limit)
 
 

--- a/opt_einsum/tests/test_contract.py
+++ b/opt_einsum/tests/test_contract.py
@@ -14,6 +14,7 @@ from opt_einsum.typing import OptimizeKind
 # NumPy is required for the majority of this file
 np = pytest.importorskip("numpy")
 
+
 tests = [
     # Test scalar-like operations
     "a,->a",
@@ -97,6 +98,18 @@ tests = [
     "dba,ead,cad->bce",
     "aef,fbc,dca->bde",
 ]
+
+
+@pytest.mark.parametrize("optimize", (True, False, None))
+def test_contract_plain_types(optimize: OptimizeKind) -> None:
+    expr = "ij,jk,kl->il"
+    ops = [np.random.rand(2, 2), np.random.rand(2, 2), np.random.rand(2, 2)]
+
+    path = contract_path(expr, *ops, optimize=optimize)
+    assert len(path) == 2
+
+    result = contract(expr, *ops, optimize=optimize)
+    assert result.shape == (2, 2)
 
 
 @pytest.mark.parametrize("string", tests)

--- a/opt_einsum/tests/test_input.py
+++ b/opt_einsum/tests/test_input.py
@@ -163,16 +163,9 @@ def test_value_errors(contract_fn: Any) -> None:
     # broadcasting to new dimensions must be enabled explicitly
     with pytest.raises(ValueError):
         contract_fn("i", np.arange(6).reshape(2, 3))
-    if contract_fn is contract:
-        # contract_path does not have an `out` parameter
-        with pytest.raises(ValueError):
-            contract_fn("i->i", [[0, 1], [0, 1]], out=np.arange(4).reshape(2, 2))
 
     with pytest.raises(TypeError):
-        contract_fn("i->i", [[0, 1], [0, 1]], bad_kwarg=True)
-
-    with pytest.raises(ValueError):
-        contract_fn("i->i", [[0, 1], [0, 1]], memory_limit=-1)
+        contract_fn("ij->ij", [[0, 1], [0, 1]], bad_kwarg=True)
 
 
 @pytest.mark.parametrize(

--- a/opt_einsum/tests/test_paths.py
+++ b/opt_einsum/tests/test_paths.py
@@ -124,7 +124,7 @@ def test_flop_cost() -> None:
 
 
 def test_bad_path_option() -> None:
-    with pytest.raises(TypeError):
+    with pytest.raises(KeyError):
         oe.contract("a,b,c", [1], [2], [3], optimize="optimall", shapes=True)  # type: ignore
 
 


### PR DESCRIPTION
## Description
This makes the final tweaks and change log notes for the upcoming v3.4.0 release.

## Todos
 - [x] Removes `np.einsum` explicit kwargs from functional definitions.

## Status
- [x] Ready to go

CC @janeyx99 