### PR TITLE
Interleaved contract_path shapes fix 

### DIFF
--- a/.github/workflows/Linting.yml
+++ b/.github/workflows/Linting.yml
@@ -76,4 +76,4 @@ jobs:
     - name: Lint
       run: |
         set -e
-        make format-check
+        make fmt-check

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,18 @@
 install:
 	pip install -e .
 
-.PHONY: format
-format:
+.PHONY: fmt
+fmt:
 	ruff check opt_einsum --fix
 	ruff format opt_einsum
 
-.PHONY: format-check
-format-check:
+.PHONY: fmt-unsafe
+fmt-unsafe:
+	ruff check opt_einsum --fix --unsafe-fixes
+	ruff format opt_einsum
+
+.PHONY: fmt-check
+fmt-check:
 	ruff check opt_einsum
 	ruff format --check opt_einsum
 

--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -297,7 +297,7 @@ def contract_path(
     input_list = input_subscripts.split(",")
     input_sets = [frozenset(x) for x in input_list]
     if shapes:
-        input_shapes = operands_prepped
+        input_shapes = list(operands_prepped)
     else:
         input_shapes = [parser.get_shape(x) for x in operands_prepped]
     output_set = frozenset(output_subscript)

--- a/opt_einsum/testing.py
+++ b/opt_einsum/testing.py
@@ -62,7 +62,7 @@ def build_views(
     dimension_dict: Optional[Dict[str, int]] = None,
     array_function: Optional[Any] = None,
     replace_ellipsis: bool = False,
-) -> Tuple[ArrayType]:
+) -> Tuple[ArrayType, ...]:
     """Builds random numpy arrays for testing.
 
     Parameters:

--- a/opt_einsum/tests/test_input.py
+++ b/opt_einsum/tests/test_input.py
@@ -150,6 +150,18 @@ def test_value_errors(contract_fn: Any) -> None:
         contract_fn("ij->ij", [[0, 1], [0, 1]], bad_kwarg=True)
 
 
+def test_input_formats_shapes():
+    """
+    Test that the shapes are the same for the bench and interleved input formats
+    """
+    shape1 = (2, 3, 4)
+    shape2 = (3, 4, 5)
+
+    bench = contract_path("abc,bcd->da", shape1, shape2, shapes=True)
+    interleved = contract_path(shape1, [1, 2, 3], shape2, [2, 3, 4], [4, 1], shapes=True)
+    assert bench[0] == interleved[0]
+
+
 @pytest.mark.parametrize(
     "string",
     [


### PR DESCRIPTION
## Description
Fixes #245 due to a tuple return rather than a mutable list when shapes are prepared.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Refactors `build_views` to work in every case rather than duplicating the test.
  - [x] Fixes #245 ensuring `input_shapes` is mutable.
  - [x] Moved to `make fmt` from `make format`, I use this abbreviation in all other projects.

## Status
- [x] Ready to go