### PR TITLE
Fix documentation build with mkdocstrings 0.29

### DIFF
--- a/docs/requirements.yml
+++ b/docs/requirements.yml
@@ -3,7 +3,7 @@ black
 devtools
 markdown==3.*
 markdown-include==0.*
-mkdocstrings[python]==0.25.*
+mkdocstrings[python]==0.29.*
 mkdocs==1.*
 mkdocs-awesome-pages-plugin==2.*
 mkdocs-exclude==1.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,25 +38,25 @@ plugins:
           # paths: [opt_einsum]
           options:
             docstring_style: google
-          docstring_options:
-            ignore_init_summary: true
-          docstring_section_style: list
-          filters: ["!^_"]
-          heading_level: 1
-          inherited_members: true
-          merge_init_into_class: true
-          parameter_headings: true
-          preload_modules: [mkdocstrings]
-          separate_signature: true
-          show_root_heading: true
-          show_root_full_path: false
-          show_signature_annotations: true
-          show_source: false
-          show_symbol_type_heading: true
-          show_symbol_type_toc: true
-          signature_crossrefs: true
-          summary: true
-          unwrap_annotated: true
+            docstring_options:
+              ignore_init_summary: true
+            docstring_section_style: list
+            filters: ["!^_"]
+            heading_level: 1
+            inherited_members: true
+            merge_init_into_class: true
+            parameter_headings: true
+            preload_modules: [mkdocstrings]
+            separate_signature: true
+            show_root_heading: true
+            show_root_full_path: false
+            show_signature_annotations: true
+            show_source: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            signature_crossrefs: true
+            summary: true
+            unwrap_annotated: true
 
 extra_javascript:
   - javascript/config.js


### PR DESCRIPTION
## Description
The previous approach to passing options to `mkdocstrings-python` started showing deprecation warnings with `mkdocstrings` 0.28.0, and started failing with `mkdocstrings` 0.28.3.

## Status
- [x] Ready to go