### PR TITLE
Fix: _einsum backend handling when optimize=False

### DIFF
--- a/opt_einsum/contract.py
+++ b/opt_einsum/contract.py
@@ -581,7 +581,8 @@ def contract(
 
     # If no optimization, run pure einsum
     if optimize is False:
-        return _einsum(*operands_list, out=out, **kwargs)
+        _backend = parse_backend(operands, backend)
+        return _einsum(*operands_list, backend=_backend, out=out, **kwargs)
 
     # Grab non-einsum kwargs
     gen_expression = kwargs.pop("_gen_expression", False)


### PR DESCRIPTION
when calling opt_einsum.contract with optimize=False, opt_einsum._einsum did not receive any backend and used numpy by default. Now the logic has been corrected.